### PR TITLE
Add support for Kubernetes v1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- Support for Kubernetes v1.17.x.
+
+### Changed
+- The API server is queried by default on the Secure Port using the service account's bearer authentication.
+  If the query on the Secure Port fails, it will fallback automatically to the non-secure one. This should preserve
+  the same behavior as previous versions.
 
 ## 1.23.1
 

--- a/deploy/newrelic-infra-unprivileged.yaml
+++ b/deploy/newrelic-infra-unprivileged.yaml
@@ -48,16 +48,12 @@ spec:
     matchLabels:
       name: newrelic-infra
   updateStrategy:
-      type: RollingUpdate # Only supported in Kubernetes version 1.6 or later.
+      type: RollingUpdate
   template:
     metadata:
       labels:
         name: newrelic-infra
         mode: unprivileged
-      annotations:
-        # Needed for Kubernetes versions prior to 1.6.0, where tolerations were set via annotations.
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"operator": "Exists", "effect": "NoSchedule"},{"operator": "Exists", "effect": "NoExecute"}]
     spec:
       serviceAccountName: newrelic
       containers:

--- a/deploy/newrelic-infra.yaml
+++ b/deploy/newrelic-infra.yaml
@@ -49,15 +49,11 @@ spec:
     matchLabels:
       name: newrelic-infra
   updateStrategy:
-      type: RollingUpdate # Only supported in Kubernetes version 1.6 or later.
+      type: RollingUpdate
   template:
     metadata:
       labels:
         name: newrelic-infra
-      annotations:
-        # Needed for Kubernetes versions prior to 1.6.0, where tolerations were set via annotations.
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"operator": "Exists", "effect": "NoSchedule"},{"operator": "Exists", "effect": "NoExecute"}]
     spec:
       serviceAccountName: newrelic
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.

--- a/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/cluster-role.yaml
+++ b/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/cluster-role.yaml
@@ -4,13 +4,16 @@ kind: ClusterRole
 metadata:
   name: {{ .Values.clusterRole.name }}
 rules:
-- apiGroups: [""]
-  resources:
-    - "nodes"
-    - "nodes/metrics"
-    - "nodes/stats"
-    - "nodes/proxy"
-    - "pods"
-    - "services"
-  verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources:
+      - "nodes"
+      - "nodes/metrics"
+      - "nodes/stats"
+      - "nodes/proxy"
+      - "pods"
+      - "secrets"
+      - "services"
+    verbs: ["get", "list"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
 {{- end }}

--- a/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
+++ b/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
@@ -54,8 +54,6 @@ spec:
               value: {{ .Values.integration.newRelicLicenseKey | quote }}
             - name: "NRIA_VERBOSE"
               value: {{ .Values.integration.verbose | int | toString | quote }}
-            - name: "API_SERVER_ENDPOINT_URL"
-              value: "https://localhost:443"
             {{- if .Values.integration.collectorURL }}
             - name: "NRIA_COLLECTOR_URL"
               value: {{ .Values.integration.collectorURL }}
@@ -81,7 +79,7 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,DISCOVERY_CACHE_DIR,DISCOVERY_CACHE_TTL,API_SERVER_ENDPOINT_URL"
+              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,DISCOVERY_CACHE_DIR,DISCOVERY_CACHE_TTL"
       volumes:
         {{- if .Values.daemonset.unprivileged }}
         - name: tmpfs-data

--- a/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
+++ b/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
@@ -19,8 +19,8 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       dnsPolicy: ClusterFirstWithHostNet
-      imagePullSecrets:
-        - name: nr-quay-secret
+      #imagePullSecrets:
+      #  - name: nr-quay-secret
       containers:
         - name: {{ .Values.daemonset.name }}
           image: "{{ .Values.daemonset.image.repository }}:{{ .Values.daemonset.image.tag }}"

--- a/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
+++ b/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
@@ -9,28 +9,18 @@ spec:
   selector:
     matchLabels:
       name: {{ .Values.daemonset.name }}
-  {{- if semverCompare ">=1.6.0" .Capabilities.KubeVersion.GitVersion }}
   updateStrategy:
       type: RollingUpdate # Only supported in Kubernetes version 1.6 or later.
-  {{- end }}
   template:
     metadata:
       labels:
         name: {{ .Values.daemonset.name }}
-      {{- if semverCompare ">=1.6.0" .Capabilities.KubeVersion.GitVersion }}
-      annotations:
-        # Needed for Kubernetes versions prior to 1.6.0, where tolerations were set via annotations.
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"operator": "Exists", "effect": "NoSchedule"},{"operator": "Exists", "effect": "NoExecute"}]
-      {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- if semverCompare ">=1.6.0" .Capabilities.KubeVersion.GitVersion }}
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.
       dnsPolicy: ClusterFirstWithHostNet
-      {{- end }}
-      #imagePullSecrets:
-      #  - name: nr-quay-secret
+      imagePullSecrets:
+        - name: nr-quay-secret
       containers:
         - name: {{ .Values.daemonset.name }}
           image: "{{ .Values.daemonset.image.repository }}:{{ .Values.daemonset.image.tag }}"
@@ -64,13 +54,11 @@ spec:
               value: {{ .Values.integration.newRelicLicenseKey | quote }}
             - name: "NRIA_VERBOSE"
               value: {{ .Values.integration.verbose | int | toString | quote }}
+            - name: "API_SERVER_ENDPOINT_URL"
+              value: "https://localhost:443"
             {{- if .Values.integration.collectorURL }}
             - name: "NRIA_COLLECTOR_URL"
               value: {{ .Values.integration.collectorURL }}
-            {{- end }}
-            {{- if (semverCompare "<1.7.6" .Capabilities.KubeVersion.GitVersion) and (.Values.integration.cadvisor) }}
-            - name: "CADVISOR_PORT" # Enable direct connection to cAdvisor by specifying the port. Needed for Kubernetes versions prior to 1.7.6.
-              value: {{ .Values.integration.cadvisor.port | quote }}
             {{- end }}
             {{- if .Values.integration.ksm }}
             - name: "KUBE_STATE_METRICS_URL" # If this value is specified then discovery process for kube-state-metrics endpoint won't be triggered.
@@ -93,7 +81,7 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,DISCOVERY_CACHE_DIR,DISCOVERY_CACHE_TTL"
+              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,DISCOVERY_CACHE_DIR,DISCOVERY_CACHE_TTL,API_SERVER_ENDPOINT_URL"
       volumes:
         {{- if .Values.daemonset.unprivileged }}
         - name: tmpfs-data
@@ -110,10 +98,8 @@ spec:
           hostPath:
             path: /var/run/docker.sock
         {{- end }}
-      {{- if semverCompare ">=1.6.0" .Capabilities.KubeVersion.GitVersion }}
       tolerations:
         - operator: "Exists"
           effect: "NoSchedule"
         - operator: "Exists"
           effect: "NoExecute"
-      {{- end }}

--- a/src/controlplane/client/discovery.go
+++ b/src/controlplane/client/discovery.go
@@ -58,10 +58,9 @@ type ControlPlaneComponentClient struct {
 
 func (c *ControlPlaneComponentClient) Do(method, urlPath string) (*http.Response, error) {
 	// Use the secure endpoint by default. If this component doesn't support it yet, fallback to the insecure one.
-	var e url.URL
-	var usingSecureEndpoint = true
-	e = c.secureEndpoint
-	if c.secureEndpoint.String() == "" {
+	e := c.secureEndpoint
+	usingSecureEndpoint := true
+	if e.String() == "" {
 		e = c.endpoint
 		usingSecureEndpoint = false
 	}
@@ -82,7 +81,8 @@ func (c *ControlPlaneComponentClient) Do(method, urlPath string) (*http.Response
 	// If there is an error, we're using the secure endpoint and insecure fallback is on, we retry using the insecure
 	// endpoint.
 	if err != nil && usingSecureEndpoint && c.InsecureFallback {
-		c.logger.Debugf("Error when calling secure endpoint, falling back to insecure.")
+		c.logger.Debugf("Error when calling secure endpoint: %s", err.Error())
+		c.logger.Debugf("Falling back to insecure endpoint")
 		e = c.endpoint
 		r, err := c.buildPrometheusRequest(method, e, urlPath)
 		if err != nil {

--- a/src/controlplane/client/discovery.go
+++ b/src/controlplane/client/discovery.go
@@ -57,7 +57,7 @@ type ControlPlaneComponentClient struct {
 }
 
 func (c *ControlPlaneComponentClient) Do(method, urlPath string) (*http.Response, error) {
-	// Use the secure endpoint by default. If it's empty, fallback to the insecure one.
+	// Use the secure endpoint by default. If this component doesn't support it yet, fallback to the insecure one.
 	var e url.URL
 	var usingSecureEndpoint = true
 	e = c.secureEndpoint
@@ -82,7 +82,7 @@ func (c *ControlPlaneComponentClient) Do(method, urlPath string) (*http.Response
 	// If there is an error, we're using the secure endpoint and insecure fallback is on, we retry using the insecure
 	// endpoint.
 	if err != nil && usingSecureEndpoint && c.InsecureFallback {
-		c.logger.Debugf("Error wen calling secure endpoint, falling back to insecure.")
+		c.logger.Debugf("Error when calling secure endpoint, falling back to insecure.")
 		e = c.endpoint
 		r, err := c.buildPrometheusRequest(method, e, urlPath)
 		if err != nil {

--- a/src/controlplane/client/discovery.go
+++ b/src/controlplane/client/discovery.go
@@ -82,6 +82,7 @@ func (c *ControlPlaneComponentClient) Do(method, urlPath string) (*http.Response
 	// If there is an error, we're using the secure endpoint and insecure fallback is on, we retry using the insecure
 	// endpoint.
 	if err != nil && usingSecureEndpoint && c.InsecureFallback {
+		c.logger.Debugf("Error wen calling secure endpoint, falling back to insecure.")
 		e = c.endpoint
 		r, err := c.buildPrometheusRequest(method, e, urlPath)
 		if err != nil {
@@ -243,6 +244,7 @@ func (sd *discoverer) Discover(timeout time.Duration) (client.HTTPClient, error)
 
 	return &ControlPlaneComponentClient{
 		endpoint:                 sd.component.Endpoint,
+		secureEndpoint:           sd.component.SecureEndpoint,
 		tlsSecretName:            sd.component.TLSSecretName,
 		tlsSecretNamespace:       sd.component.TLSSecretNamespace,
 		InsecureFallback:         sd.component.InsecureFallback,

--- a/src/controlplane/components.go
+++ b/src/controlplane/components.go
@@ -21,6 +21,8 @@ type Component struct {
 	TLSSecretName                   string
 	TLSSecretNamespace              string
 	Endpoint                        url.URL
+	SecureEndpoint                  url.URL
+	InsecureFallback                bool
 	UseServiceAccountAuthentication bool
 	UseMTLSAuthentication           bool
 	Specs                           definition.SpecGroups
@@ -174,11 +176,17 @@ func BuildComponentList(options ...ComponentOption) []Component {
 				// OpenShift
 				{"app": "openshift-kube-apiserver", "apiserver": "true"},
 			},
-			Queries: metric.APIServerQueries,
-			Specs:   metric.APIServerSpecs,
+			Queries:                         metric.APIServerQueries,
+			Specs:                           metric.APIServerSpecs,
+			UseServiceAccountAuthentication: true,
+			InsecureFallback:                true,
 			Endpoint: url.URL{
 				Scheme: "http",
 				Host:   "localhost:8080",
+			},
+			SecureEndpoint: url.URL{
+				Scheme: "https",
+				Host:   "localhost:443",
 			},
 		},
 	}


### PR DESCRIPTION
This adds support for Kubernetes v1.17.

Basically now the metrics from the API server are being queried over the secure port (443) by default. If the query to the secure port fails, we automatically and transparently fallback to the insecure one.