### PR TITLE
Add Kubernetes 1.17.9 E2E cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,17 +83,17 @@ pipeline {
 
     stage('Privileged e2e tests') {
       parallel {
-        stage('Privileged: 1.14.6')    { steps { runPrivilegedE2ETest('v2-e2e-cluster-1-14-6') } }
         stage('Privileged: 1.15.7')    { steps { runPrivilegedE2ETest('v2-e2e-cluster-1-15-7') } }
         stage('Privileged: 1.16.7')    { steps { runPrivilegedE2ETest('e2e-cluster-1-16-7') } }
+        stage('Privileged: 1.17.9')    { steps { runPrivilegedE2ETest('e2e-cluster-1-17-9') } }
       }
     }
 
     stage('Unprivileged e2e tests') {
       parallel {
-        stage('Unprivileged: 1.14.6')  { steps { runUnprivilegedE2ETest('v2-e2e-cluster-1-14-6') } }
         stage('Unprivileged: 1.15.7')  { steps { runUnprivilegedE2ETest('v2-e2e-cluster-1-15-7') } }
         stage('Unprivileged: 1.16.7')  { steps { runUnprivilegedE2ETest('e2e-cluster-1-16-7') } }
+        stage('Unprivileged: 1.17.9')  { steps { runUnprivilegedE2ETest('e2e-cluster-1-17-9') } }
       }
     }
   }

--- a/e2e/schema/deployment.json
+++ b/e2e/schema/deployment.json
@@ -79,7 +79,6 @@
     "podsDesired",
     "podsTotal",
     "podsUnavailable",
-    "podsUpdated",
-    "podsMaxUnavailable"
+    "podsUpdated"
   ]
 }

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -535,7 +535,7 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "podsAvailable", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_available"), Type: sdkMetric.GAUGE},
 			{Name: "podsUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_unavailable"), Type: sdkMetric.GAUGE},
 			{Name: "podsUpdated", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_updated"), Type: sdkMetric.GAUGE},
-			{Name: "podsMaxUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_unavailable"), Type: sdkMetric.GAUGE},
+			{Name: "podsMaxUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_unavailable"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "deploymentName", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "deployment"), Type: sdkMetric.ATTRIBUTE},


### PR DESCRIPTION
This PR will add 2 new E2E clusters: 1.17.9 & 1.18.x