### PR TITLE
Release 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   For Pods, this issue is mainly present when using hostNetwok since they
   shared the same network interfaces with the Node.
 
+- Upgraded Docker base image `newrelic/infrastructure-bundle` to v1.4.2.
+  For more information on the release please see the [New Relic Infrastructure Bundle release notes](https://github.com/newrelic/infrastructure-bundle/releases/tag/1.4.2).
 ## 1.25.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## 1.26.0
+
+### Changed
 - When querying the summary endpoint from Kubelet to get the Node or Pod
   network metrics, if the default network interface is not eth0 then summary
   endpoint for Kubelet doesn't return the metrics as we expect them. We rely on

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_NAME=newrelic/infrastructure-bundle
-ARG IMAGE_TAG=1.4.1
+ARG IMAGE_TAG=1.4.2
 ARG MODE=normal
 
 FROM $IMAGE_NAME:$IMAGE_TAG AS base

--- a/deploy/newrelic-infra-unprivileged.yaml
+++ b/deploy/newrelic-infra-unprivileged.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: newrelic
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.25.0-unprivileged
+          image: newrelic/infrastructure-k8s:1.26.0-unprivileged
           resources:
             limits:
               memory: 150M

--- a/deploy/newrelic-infra.yaml
+++ b/deploy/newrelic-infra.yaml
@@ -60,7 +60,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.25.0
+          image: newrelic/infrastructure-k8s:1.26.0
           securityContext:
             privileged: true
           resources:

--- a/src/kubernetes.go
+++ b/src/kubernetes.go
@@ -70,7 +70,7 @@ const (
 	defaultDiscoveryCacheTTL           = time.Hour
 
 	integrationName    = "com.newrelic.kubernetes"
-	integrationVersion = "1.25.0"
+	integrationVersion = "1.26.0"
 	nodeNameEnvVar     = "NRK8S_NODE_NAME"
 )
 


### PR DESCRIPTION
I see one of the commit messages is wrong (references 1.16.0 instead of 1.26.0). It'll be fixed when squash merging the PR. 