### PR TITLE
chore: Updated infrastructure-bundle to v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.26.1
+- Upgraded Docker base image `newrelic/infrastructure-bundle` to v1.5.0.
+  For more information on the release please see the [New Relic Infrastructure Bundle release notes](https://github.com/newrelic/infrastructure-bundle/releases/tag/1.5.0).
+
+### Changed
+
 ## 1.26.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ## 1.26.1
-- Upgraded Docker base image `newrelic/infrastructure-bundle` to v1.5.0.
-  For more information on the release please see the [New Relic Infrastructure Bundle release notes](https://github.com/newrelic/infrastructure-bundle/releases/tag/1.5.0).
 
 ### Changed
+
+- Upgraded Docker base image `newrelic/infrastructure-bundle` to v1.5.0.
+  For more information on the release please see the [New Relic Infrastructure Bundle release notes](https://github.com/newrelic/infrastructure-bundle/releases/tag/1.5.0).
 
 ## 1.26.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_NAME=newrelic/infrastructure-bundle
-ARG IMAGE_TAG=1.4.2
+ARG IMAGE_TAG=1.5.0
 ARG MODE=normal
 
 FROM $IMAGE_NAME:$IMAGE_TAG AS base

--- a/deploy/newrelic-infra-unprivileged.yaml
+++ b/deploy/newrelic-infra-unprivileged.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: newrelic
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.26.0-unprivileged
+          image: newrelic/infrastructure-k8s:1.26.1-unprivileged
           resources:
             limits:
               memory: 150M

--- a/deploy/newrelic-infra.yaml
+++ b/deploy/newrelic-infra.yaml
@@ -60,7 +60,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.26.0
+          image: newrelic/infrastructure-k8s:1.26.1
           securityContext:
             privileged: true
           resources:

--- a/src/kubernetes.go
+++ b/src/kubernetes.go
@@ -70,7 +70,7 @@ const (
 	defaultDiscoveryCacheTTL           = time.Hour
 
 	integrationName    = "com.newrelic.kubernetes"
-	integrationVersion = "1.26.0"
+	integrationVersion = "1.26.1"
 	nodeNameEnvVar     = "NRK8S_NODE_NAME"
 )
 


### PR DESCRIPTION
Updated to latest version of bundle agent,  [v1.5.0](https://github.com/newrelic/infrastructure-bundle/releases/tag/1.5.0)