### PR TITLE
Use Tini entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ ENV NRIA_OVERRIDE_HOST_ROOT ""
 ENV NRIA_IS_SECURE_FORWARD_ONLY true
 
 FROM branch-${MODE}
-ENTRYPOINT ["/usr/bin/newrelic-infra"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/usr/bin/newrelic-infra"]


### PR DESCRIPTION
Reopened from #21 using a local branch to get the CI running 

This:
- reaps orphaned zombie process attached to PID 1
- correctly forwards signals to CMD process

Base infrastructure agent image uses it: https://hub.docker.com/layers/newrelic/infrastructure/latest/images/sha256-509908017550b739445db36cb7172b267d51fcc21ab28fc3b5532b4868191585?context=explore

Read for more details: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/