### PR TITLE
fix: add restart count metric to waiting pods

### DIFF
--- a/src/kubelet/metric/pods.go
+++ b/src/kubelet/metric/pods.go
@@ -218,6 +218,7 @@ func fillContainerStatuses(pod *v1.Pod, dest map[string]definition.RawMetrics) {
 		case c.State.Waiting != nil:
 			dest[id]["status"] = "Waiting"
 			dest[id]["reason"] = c.State.Waiting.Reason
+			dest[id]["restartCount"] = c.RestartCount
 		case c.State.Terminated != nil:
 			dest[id]["status"] = "Terminated"
 			dest[id]["reason"] = c.State.Terminated.Reason


### PR DESCRIPTION
in case a pod is in a crash loop we were not getting the restart count.