### PR TITLE
Correctly fail DNS discovery for KSM behind headless services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- When discovering kube-state-metrics behind a headless service, the
+  DNS discovery will return an error. Before it would be considered
+  successfull and return "None" as endpoint.
+
 ## 1.26.5
 
 ### Fixed

--- a/src/ksm/client/discovery_test.go
+++ b/src/ksm/client/discovery_test.go
@@ -30,6 +30,12 @@ func emptyLookupSRV(service, proto, name string) (cname string, addrs []*net.SRV
 	return "cname", []*net.SRV{}, nil
 }
 
+func noneLookupSRV(service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	return "cname", []*net.SRV{{
+		Target: "None",
+	}}, nil
+}
+
 func failingLookupSRV(service, proto, name string) (cname string, addrs []*net.SRV, err error) {
 	return "cname", nil, fmt.Errorf("patapum")
 }
@@ -103,13 +109,17 @@ func TestDiscover_portThroughDNSAndGuessedNodeIPFromMultiplePods(t *testing.T) {
 	// And the nodeIP is correctly returned
 	assert.Equal(t, "162.178.1.1", ksmClient.(*ksm).nodeIP)
 }
-func TestDiscover_metricsPortThroughAPIWhenDNSEmptyResponse(t *testing.T) {
+func TestDiscover_metricsPortThroughAPIWhenDNSFails(t *testing.T) {
 	tt := []struct {
 		label string
+		srvLookup lookupSRVFunc
 	}{
-		{"k8s-app"},
-		{"app"},
-		{"app.kubernetes.io/name"},
+		{"k8s-app", emptyLookupSRV},
+		{"app", emptyLookupSRV},
+		{"app.kubernetes.io/name", emptyLookupSRV},
+		{"k8s-app", noneLookupSRV},
+		{"app", noneLookupSRV},
+		{"app.kubernetes.io/name", noneLookupSRV},
 	}
 
 	for _, entry := range tt {

--- a/src/ksm/client/discovery_test.go
+++ b/src/ksm/client/discovery_test.go
@@ -111,7 +111,7 @@ func TestDiscover_portThroughDNSAndGuessedNodeIPFromMultiplePods(t *testing.T) {
 }
 func TestDiscover_metricsPortThroughAPIWhenDNSFails(t *testing.T) {
 	tt := []struct {
-		label string
+		label     string
 		srvLookup lookupSRVFunc
 	}{
 		{"k8s-app", emptyLookupSRV},


### PR DESCRIPTION
Kubernetes returns "None" as the clusterIP of headless Services.

This was causing the KSM discovery to think the DNS based discovery was successful, when in fact the returned IP is `"None"` and cannot be reached.

With this patch if the returned clusterIP is `"None"` it will be automatically skipped. And if it's the only address found, the DNS discovery will fail.