### PR TITLE
feat(baseImage): updating base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 2.0.0
+
+### Changed
+
+- The base image of `newrelic/infrastructure-k8s` has been updated to `2.0.0`. 
+  That base image is bundling the integration `nri-nginx` `3.0.2` that contains a breaking change. 
+  More info regarding all the integration upgraded can be found in the [release notes of the base image](https://github.com/newrelic/infrastructure-bundle/releases/tag/2.0.0).
+
+
 ## 1.26.9
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_NAME=newrelic/infrastructure-bundle
-ARG IMAGE_TAG=1.6.0
+ARG IMAGE_TAG=2.0.0
 ARG MODE=normal
 
 FROM $IMAGE_NAME:$IMAGE_TAG AS base

--- a/deploy/newrelic-infra-unprivileged.yaml
+++ b/deploy/newrelic-infra-unprivileged.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: newrelic
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.26.9-unprivileged
+          image: newrelic/infrastructure-k8s:2.0.0-unprivileged
           resources:
             limits:
               memory: 150M

--- a/deploy/newrelic-infra.yaml
+++ b/deploy/newrelic-infra.yaml
@@ -60,7 +60,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: newrelic-infra
-          image: newrelic/infrastructure-k8s:1.26.9
+          image: newrelic/infrastructure-k8s:2.0.0
           securityContext:
             privileged: true
           resources:

--- a/src/kubernetes.go
+++ b/src/kubernetes.go
@@ -70,7 +70,7 @@ const (
 	defaultDiscoveryCacheTTL           = time.Hour
 
 	integrationName    = "com.newrelic.kubernetes"
-	integrationVersion = "1.26.9"
+	integrationVersion = "2.0.0"
 	nodeNameEnvVar     = "NRK8S_NODE_NAME"
 )
 


### PR DESCRIPTION
Bumping base image to update all the bundled integrations.


More info regarding all the integration upgraded can be found in the [release notes of the base image](https://github.com/newrelic/infrastructure-bundle/releases/tag/2.0.0).