### PR TITLE
Retrieve load balancer IP from kube_service_status_load_balancer_ingress

### DIFF
--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -776,6 +776,7 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_service_created"},
 	{MetricName: "kube_service_labels"},
 	{MetricName: "kube_service_info"},
+	{MetricName: "kube_service_status_load_balancer_ingress"},
 	{MetricName: "kube_service_spec_type", Value: prometheus.QueryValue{
 		Value: prometheus.GaugeValue(1),
 	}},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -591,7 +591,7 @@ var KSMSpecs = definition.SpecGroups{
 			},
 			{
 				Name:      "loadBalancerIP",
-				ValueFunc: prometheus.FromLabelValue("kube_service_info", "load_balancer_ip"),
+				ValueFunc: prometheus.FromLabelValue("kube_service_status_load_balancer_ingress", "ip"),
 				Type:      sdkMetric.ATTRIBUTE,
 				Optional:  true,
 			},


### PR DESCRIPTION
Previously, the `LoadBalancerIP` field was retrieved from `kube_service_info.load_balancer_ip`. This value, however, seems to be blank for the current ksm version.

This PR changes it to be retrieved from `kube_service_status_load_balancer_ingress.ip`, which seems to be working with the current version.

Temporary images images for testing are available:
- `roobre/infrastructure-k8s:load-balancer`
- `roobre/infrastructure-k8s:load-balancer-unprivileged`

### Tasks
- [ ] Investigate whether this is still needed/recommended in newer kube-state-metrics versions
- [ ] Add a test case for this

---

Fixes #74