### PR TITLE
fix upgrade-chart dispatch

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -20,7 +20,7 @@ jobs:
             "client_payload":{
               "chart_name":"${CHART_NAME}",
               "chart_version":"",
-              "app_version":"${APP_VERSION:1}"
+              "app_version":"${APP_VERSION/v/}"
             }
           }
           EOF

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -6,13 +6,21 @@ on:
 jobs:
   create_helm_chart_pr:
     runs-on: ubuntu-latest
+    env:
+      CHART_NAME: newrelic-infrastructure
+      APP_VERSION: ${{ github.event.release.tag_name }}
     steps:
       - name: Create PR using Version Bump
         run: |
-          appVersion=${{ github.event.release.tag_name }}
-          chartName=newrelic-infrastructure
           curl -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Authorization: token ${{ secrets.VERSION_BUMP_TOKEN }}" \
-          --request POST \
-          --data '{"event_type": "bump-chart-version", "client_payload": { "chart_name": "${chartName}", "chart_version": "", "app_version": "${appVersion:1}"}}' \
-          https://api.github.com/repos/newrelic/helm-charts/dispatches
+          -d @- https://api.github.com/repos/newrelic/helm-charts/dispatches <<EOF
+          {
+            "event_type":"bump-chart-version",
+            "client_payload":{
+              "chart_name":"${CHART_NAME}",
+              "chart_version":"",
+              "app_version":"${APP_VERSION:1}"
+            }
+          }
+          EOF


### PR DESCRIPTION
Previously, the `curl` command in this job used `$variables` enclosed in `'single quoted strings'`, which prevented their expansion. This PR fixes that.