### PR TITLE
fix: filter symbol from server version

### DIFF
--- a/src/featureflag/static_pod_status.go
+++ b/src/featureflag/static_pod_status.go
@@ -10,6 +10,7 @@ into a more robust and flexible implementation.
 package featureflag
 
 import (
+	"regexp"
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/version"
@@ -23,14 +24,16 @@ func StaticPodsStatus(v *version.Info) bool {
 	if v == nil {
 		return false
 	}
-	major, err := strconv.Atoi(v.Major)
+	// this regex is used to strip any symbol from the version and take the first left match after
+	r := regexp.MustCompile("([0-9]+)")
+	major, err := strconv.Atoi(r.FindString(v.Major))
 	if err != nil {
 		return false
 	}
 	if major > 1 {
 		return true
 	}
-	minor, err := strconv.Atoi(v.Minor)
+	minor, err := strconv.Atoi(r.FindString(v.Minor))
 	if err != nil {
 		return false
 	}

--- a/src/featureflag/static_pod_status_test.go
+++ b/src/featureflag/static_pod_status_test.go
@@ -33,6 +33,21 @@ func TestStaticPodStatus(t *testing.T) {
 			version:  &version.Info{Major: "1", Minor: "14"},
 			expected: false,
 		},
+		{
+			name:     "major is the same and minor has symbol",
+			version:  &version.Info{Major: "1", Minor: "18+"},
+			expected: true,
+		},
+		{
+			name:     "major is the same and minor has patch",
+			version:  &version.Info{Major: "1", Minor: "18.12"},
+			expected: true,
+		},
+		{
+			name:     "major is the same and minor has patch less than supported",
+			version:  &version.Info{Major: "1", Minor: "13.12"},
+			expected: false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
We found that on GKE the minor version of the k8s server contained a symbol and that was causing that `StaticPodsStatus(v *version.Info)` failed to detect if the version was grater than 1.14. This caused static pods not being appropriately synced.

json sample of the version input:
```json
Server Version: version.Info{Major: "1", Minor: "18+",
```
This PR adds a regex to strip any character from the version and take the first left match. 

Note: There are some packages to compare semantic version but in this case the string does not match a [semantic version regex](https://regex101.com/r/Ly7O1x/3/) so is useless for this particular case.