### PR TITLE
ksm/discovery: try several well-known port names

### DIFF
--- a/src/ksm/client/discovery.go
+++ b/src/ksm/client/discovery.go
@@ -26,7 +26,6 @@ const (
 	ksmAppLabelValue         = "kube-state-metrics"
 	k8sTCP                   = "TCP"
 	ksmQualifiedName         = "kube-state-metrics.kube-system.svc.cluster.local"
-	ksmDNSService            = "http-metrics"
 	ksmDNSProto              = "tcp"
 	headlessServiceClusterIP = "None"
 )

--- a/src/ksm/client/discovery_test.go
+++ b/src/ksm/client/discovery_test.go
@@ -131,7 +131,7 @@ func TestDiscover_metricsPortThroughAPIWhenDNSFails(t *testing.T) {
 					Spec: v1.ServiceSpec{
 						ClusterIP: "1.2.3.4",
 						Ports: []v1.ServicePort{{
-							Name: ksmPortName,
+							Name: ksmPortNames[0],
 							Port: 8888,
 						}},
 					},
@@ -179,7 +179,7 @@ func TestDiscover_metricsPortThroughAPIWhenDNSError(t *testing.T) {
 			Spec: v1.ServiceSpec{
 				ClusterIP: "1.2.3.4",
 				Ports: []v1.ServicePort{{
-					Name: ksmPortName,
+					Name: ksmPortNames[0],
 					Port: 8888,
 				}},
 			},


### PR DESCRIPTION
Previously, when performing DNS discovery, we were looking for a port named `http-metrics`.

It would seem that this port is no longer used by `ksm` by default, and now just `http` is used. This PR adds the ability to search for both.