### PR TITLE
Selecting only pods we are interested about in E2E

### DIFF
--- a/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
+++ b/e2e/charts/newrelic-infrastructure-k8s-e2e/templates/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         name: {{ .Values.daemonset.name }}
+        releaseName: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}-{{ .Release.Name }}
       hostNetwork: true # This option is a requirement for the Infrastructure Agent to report the proper hostname in New Relic.

--- a/e2e/cmd/e2e.go
+++ b/e2e/cmd/e2e.go
@@ -311,10 +311,12 @@ func executeTests(
 	logger *logrus.Logger,
 	currentScenario scenario.Scenario,
 ) error {
+
+	releaseLabel := fmt.Sprintf("releaseName=%s", releaseName)
 	// We're fetching the list of NR pods here just to fetch it once. If for
 	// some reason this list or the contents of it could change during the
 	// execution of these tests, we could move it to `test*` functions.
-	podsList, err := c.PodsListByLabels(namespace, []string{nrLabel})
+	podsList, err := c.PodsListByLabels(namespace, []string{nrLabel, releaseLabel})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The current E2E implementation is selecting all pods available with the infra label, however this could lead to select `terminating` pods of previous release. This causes annoying false errors in tests complaining about containers not found.