### PR TITLE
dockerfile: hardcode IMAGE_NAME and IMAGE_TAG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-ARG IMAGE_NAME=newrelic/infrastructure-bundle
-ARG IMAGE_TAG=2.4.1
-
 ARG MODE=normal
 
-FROM $IMAGE_NAME:$IMAGE_TAG AS base
+FROM newrelic/infrastructure-bundle:2.5.0 AS base
 
 # Set by docker automatically
 # If building with `docker build`, make sure to set GOOS/GOARCH explicitly when calling make:


### PR DESCRIPTION
Those build args were not being used anywhere in the pipeline. If they were, versions would be defined in two different places, hurting maintainability.
Moreover, by having a "standard" `FROM` line, we can make use of Dependabot's bumping feature for the base image.