### PR TITLE
Add nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,100 @@
+name: Nightly build
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  build:
+    name: Build integration for
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [ linux ]
+        goarch: [ amd64, arm64, arm ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - name: Build integration
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          make compile
+      - name: Upload artifact for docker build step
+        uses: actions/upload-artifact@v2
+        with:
+          retention-days: 1
+          name: nri-kubernetes-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: bin/nri-kubernetes-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  docker:
+    name: Build and push images
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE_NAME: newrelic/infrastructure-k8s
+      DOCKER_IMAGE_TAG: nightly
+      DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/arm" # Must be consistent with the matrix from the job above
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download all artifacts from build job
+        uses: actions/download-artifact@v2
+        with:
+          path: bin
+
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
+
+      - name: Build docker images
+        run: |
+          docker buildx build --platform=$DOCKER_PLATFORMS \
+            --build-arg 'BASE_IMAGE=newrelic/infrastructure-bundle-nightly' \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+            .
+          docker buildx build --platform=$DOCKER_PLATFORMS \
+            --build-arg 'MODE=unprivileged' \
+            --build-arg 'BASE_IMAGE=newrelic/infrastructure-bundle-nightly' \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG-unprivileged \
+            .
+
+      - name: Build and load x64 image for security scanning
+        # We need to build a single-arch image again to be able to --load it into the host
+        run: |
+          docker buildx build --load --platform=linux/amd64 \
+            -t $DOCKER_IMAGE_NAME:ci-scan \
+            .
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.0.18
+        with:
+          image-ref: '${{ env.DOCKER_IMAGE_NAME }}:ci-scan'
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - name: Push images
+        run: |
+          docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            --build-arg 'BASE_IMAGE=newrelic/infrastructure-bundle:nightly' \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+            .
+          docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            --build-arg 'MODE=unprivileged' \
+            --build-arg 'BASE_IMAGE=newrelic/infrastructure-bundle:nightly' \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG-unprivileged \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG MODE=normal
+ARG BASE_IMAGE=newrelic/infrastructure-bundle:2.6.0
 
-FROM newrelic/infrastructure-bundle:2.6.0 AS base
+FROM $BASE_IMAGE AS base
 
 # Set by docker automatically
 # If building with `docker build`, make sure to set GOOS/GOARCH explicitly when calling make:


### PR DESCRIPTION
This PR adds new GitHub Actions workflow, which will build and push
integration Docker images daily, so one can use those images in bleeding
edge environments to spot any potential issues.

Based on https://github.com/newrelic/infrastructure-bundle/pull/67

Closes #125