### PR TITLE
kubernetes-static: log with logrus rather than fmt.Println

### DIFF
--- a/cmd/kubernetes-static/main.go
+++ b/cmd/kubernetes-static/main.go
@@ -225,7 +225,7 @@ func startStaticMetricsServer(content embed.FS, k8sMetricsVersion string) string
 	}
 
 	endpoint := fmt.Sprintf("http://%s", listener.Addr())
-	fmt.Println("Hosting Mock Metrics data on:", endpoint)
+	logrus.Infof("Hosting Mock Metrics data on: %s", endpoint)
 
 	mux := http.NewServeMux()
 

--- a/cmd/kubernetes-static/main.go
+++ b/cmd/kubernetes-static/main.go
@@ -225,7 +225,7 @@ func startStaticMetricsServer(content embed.FS, k8sMetricsVersion string) string
 	}
 
 	endpoint := fmt.Sprintf("http://%s", listener.Addr())
-	logrus.Infof("Hosting Mock Metrics data on: %s", endpoint)
+	logrus.Infof("Hosting Mock Metrics data on %s", endpoint)
 
 	mux := http.NewServeMux()
 


### PR DESCRIPTION
The former makes stdout not json-conformant and cannot be piped to jq, which annoys me to ontological levels