### PR TITLE
ci: run nightly job at 4AM

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly build
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 4 * * *"
   push:
     branches:
       - master


### PR DESCRIPTION
`infrastructure-bundle` image runs at 3AM, which does not leave enough time for this nightly to be built on top of the `infratructure-bundle` nightly of the same day.

https://github.com/newrelic/infrastructure-bundle/blob/846e97b3e0d3817aa37d7a0f1ca1eb30c504ad6c/.github/workflows/nightly.yml#L4