### PR TITLE
Allow testutil.Asserter to use user-defined excludeFuncs

### DIFF
--- a/internal/testutil/assert.go
+++ b/internal/testutil/assert.go
@@ -122,12 +122,12 @@ func (a Asserter) Assert(t *testing.T) {
 
 				if a.shouldExclude(groupName, &spec, entity) {
 					if !a.silent {
-						t.Logf("excluded metric %q not found in entity %q", spec.Name, entity.Metadata.Name)
+						t.Logf("excluded metric %q not found in entity %q (%s)", spec.Name, entity.Metadata.Name, entity.Metadata.Namespace)
 					}
 					continue
 				}
 
-				t.Errorf("metric %q not found in entity %q %q", spec.Name, entity.Metadata.Namespace, entity.Metadata.Name)
+				t.Errorf("metric %q not found in entity %q (%s)", spec.Name, entity.Metadata.Name, entity.Metadata.Namespace)
 				t.Failed()
 			}
 		}

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -19,9 +19,11 @@ func TestScraper(t *testing.T) {
 	asserter := testutil.NewAsserter().
 		Using(metric.KSMSpecs).
 		// TODO(roobre): We should not exclude Optional, pod or hpa metrics. To be tackled in a follow-up PR.
-		ExcludingOptional().
-		Excluding("pod").
-		Excluding("hpa")
+		Excluding(
+			testutil.ExcludeOptional(),
+			testutil.ExcludeGroup("pod"),
+			testutil.ExcludeGroup("hpa"),
+		)
 
 	for _, version := range testutil.AllVersions() {
 		t.Run(fmt.Sprintf("for_version_%s", version), func(t *testing.T) {

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -19,10 +19,9 @@ func TestScraper(t *testing.T) {
 	asserter := testutil.NewAsserter().
 		Using(metric.KSMSpecs).
 		// TODO(roobre): We should not exclude Optional, pod or hpa metrics. To be tackled in a follow-up PR.
+		ExcludingGroups("hpa", "pod").
 		Excluding(
 			testutil.ExcludeOptional(),
-			testutil.ExcludeGroup("pod"),
-			testutil.ExcludeGroup("hpa"),
 		)
 
 	for _, version := range testutil.AllVersions() {

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -20,9 +20,7 @@ func TestScraper(t *testing.T) {
 		Using(metric.KSMSpecs).
 		// TODO(roobre): We should not exclude Optional, pod or hpa metrics. To be tackled in a follow-up PR.
 		ExcludingGroups("hpa", "pod").
-		Excluding(
-			testutil.ExcludeOptional(),
-		)
+		Excluding(testutil.ExcludeOptional())
 
 	for _, version := range testutil.AllVersions() {
 		t.Run(fmt.Sprintf("for_version_%s", version), func(t *testing.T) {


### PR DESCRIPTION
This ~tentative~ PR introduces `ExcludeFunc`, a function that can be user-defined and returns true if a metric should be allowed to be missing from the test.

This can be used to handle complex scenarios, like excluding/including a metric only if an entity matches a pattern. For example, with the previously known problem of not failing for container memory limit metrics one could do:

```go
	asserter := testutil.NewAsserter().
		Using(metric.KubeletSpecs).
		Excluding(func(group string, spec *definition.Spec, ent *integration.Entity) bool {
			return group == "container" && spec.Name == "memoryLimitBytes" && ent.Metadata.Name != "container-with-limits"  
		})
```

This way we will exclude the `memoryLimitBytes` metric for `group == "container"` if the entity is not named `container-with-limits`, which could be a container we specifically deploy in our `e2e-resources` chart with limits associated.

`testutil` package already includes some wrappers that return `ExcludeFunc`s, like `ExcludeOptional`, or `ExcludeMetric` which implement the same behavior that previously was built-in into the asserter.

As a not-so-pretty drawback of this approach, whole metric groups need to be excluded through a different mechanism, `ExcludingGroups`. The reason for this is that in order for the test to not fail where there are not any entities for an excluded group, the asserter needs to check this before iterating over the entities mapped to that group. This means it cannot call an `ExcludeFunc` as `entity` and `spec` would be `nil`. This could be set as a constraint for the `ExcludeFunc` API, but we thought this would be more unexpected and confusing than having a separate mechanism for excluding groups.

~In the current state this apprach is broken, as the asserter cannot apply groupExclusions before attempting to check if any entity is there.~