### PR TITLE
Disable renovate dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    // Disable the creation of this issue that renovate updates with the pending issue we follow with Zenhub:
+    // https://github.com/newrelic/nri-kubernetes/issues/205
+    ":disableDependencyDashboard"
   ],
   "enabledManagers": [
     // Enable only the regex manager (for Dockerfile base image bumping). Go dependencies are managed by Dependabot.


### PR DESCRIPTION
Renovate dashboard is a feature that creates an issue that updates with the pending updates that this repository has: https://docs.renovatebot.com/key-concepts/dashboard/

We follow these PRs renovate (and dependabot) creates using Zenhub.

Solves #205