### PR TITLE
Update tests to new testdata format introduced in #281

### DIFF
--- a/cmd/kubernetes-static/main.go
+++ b/cmd/kubernetes-static/main.go
@@ -10,6 +10,10 @@ import (
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/newrelic/nri-kubernetes/v2/internal/discovery"
 	"github.com/newrelic/nri-kubernetes/v2/internal/testutil"
 	"github.com/newrelic/nri-kubernetes/v2/src/data"
@@ -20,9 +24,6 @@ import (
 	kubeletmetric "github.com/newrelic/nri-kubernetes/v2/src/kubelet/metric"
 	"github.com/newrelic/nri-kubernetes/v2/src/metric"
 	"github.com/newrelic/nri-kubernetes/v2/src/scrape"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 const (
@@ -49,7 +50,13 @@ func main() {
 		logrus.Fatalf("Error building testserver: %v", err)
 	}
 
-	fakeK8s := fake.NewSimpleClientset(testutil.K8sEverything()...)
+	k8sData, err := testutil.LatestVersion().K8s()
+	if err != nil {
+		logrus.Fatalf("error instantiating fake k8s objects: %v", err)
+	}
+
+	fakeK8s := fake.NewSimpleClientset(k8sData.Everything()...)
+
 	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	if err != nil {
 		logrus.Fatal(err)

--- a/internal/testutil/k8s.go
+++ b/internal/testutil/k8s.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	servicesFile   = "services.yaml"
-	nodesFile      = "nodes.yaml"
+	endpointsFile  = "endpoints.yaml"
 	namespacesFile = "namespaces.yaml"
+	nodesFile      = "nodes.yaml"
+	podsFile       = "pods.yaml"
+	servicesFile   = "services.yaml"
 )
 
 type K8s struct {
@@ -30,9 +32,11 @@ func newK8s(v Version) (K8s, error) {
 
 func (k K8s) Everything() []runtime.Object {
 	return []runtime.Object{
+		k.Endpoints(),
 		k.Namespaces(),
-		k.Services(),
 		k.Nodes(),
+		k.Pods(),
+		k.Services(),
 	}
 }
 
@@ -57,6 +61,24 @@ func (k K8s) Services() runtime.Object {
 func (k K8s) Nodes() runtime.Object {
 	var nodes corev1.NodeList
 	if err := k.loadYaml(&nodes, nodesFile); err != nil {
+		panic(err)
+	}
+
+	return &nodes
+}
+
+func (k K8s) Endpoints() runtime.Object {
+	var nodes corev1.EndpointsList
+	if err := k.loadYaml(&nodes, endpointsFile); err != nil {
+		panic(err)
+	}
+
+	return &nodes
+}
+
+func (k K8s) Pods() runtime.Object {
+	var nodes corev1.PodList
+	if err := k.loadYaml(&nodes, podsFile); err != nil {
 		panic(err)
 	}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -18,6 +18,11 @@ func (v Version) Server() (*Server, error) {
 	return newServer(v)
 }
 
+// K8s returns a helper that provide fake instances of K8s objects, ready to use with the kubernetes fake client.
+func (v Version) K8s() (K8s, error) {
+	return newK8s(v)
+}
+
 // List of all the versions we have testdata for.
 // When adding a new version:
 // - REMEMBER TO ADD IT TO AllVersions() BELOW.

--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -11,15 +11,16 @@ import (
 	"time"
 
 	"github.com/newrelic/infra-integrations-sdk/integration"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/newrelic/nri-kubernetes/v2/internal/config"
 	"github.com/newrelic/nri-kubernetes/v2/internal/testutil"
 	"github.com/newrelic/nri-kubernetes/v2/src/controlplane"
 	"github.com/newrelic/nri-kubernetes/v2/src/definition"
 	"github.com/newrelic/nri-kubernetes/v2/src/metric"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 var (
@@ -64,7 +65,12 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 				t.Fatalf("Cannot create fake KSM server: %v", err)
 			}
 
-			fakeK8s := fake.NewSimpleClientset(testutil.K8sEverything()...)
+			k8sData, err := version.K8s()
+			if err != nil {
+				t.Fatalf("error instantiating fake k8s objects: %v", err)
+			}
+
+			fakeK8s := fake.NewSimpleClientset(k8sData.Everything()...)
 
 			i := testutil.NewIntegration(t)
 
@@ -107,7 +113,12 @@ func Test_Scraper_Autodiscover_cp_component_after_start(t *testing.T) {
 		t.Fatalf("Cannot create fake KSM server: %v", err)
 	}
 
-	fakeK8s := fake.NewSimpleClientset(testutil.K8sEverything()...)
+	k8sData, err := testutil.LatestVersion().K8s()
+	if err != nil {
+		t.Fatalf("error instantiating fake k8s objects: %v", err)
+	}
+
+	fakeK8s := fake.NewSimpleClientset(k8sData.Everything()...)
 
 	i := testutil.NewIntegration(t)
 
@@ -167,7 +178,12 @@ func Test_Scraper_external_endpoint(t *testing.T) {
 		t.Fatalf("Cannot create fake KSM server: %v", err)
 	}
 
-	fakeK8s := fake.NewSimpleClientset(testutil.K8sEverything()...)
+	k8sData, err := testutil.LatestVersion().K8s()
+	if err != nil {
+		t.Fatalf("error instantiating fake k8s objects: %v", err)
+	}
+
+	fakeK8s := fake.NewSimpleClientset(k8sData.Everything()...)
 
 	i := testutil.NewIntegration(t)
 

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -39,7 +39,9 @@ func TestScraper(t *testing.T) {
 		)
 
 	// TODO: use testutil.AllVersions() when all versions are generated with datagen.sh.
-	for _, version := range []testutil.Version{testutil.Testdata120, testutil.Testdata121, testutil.Testdata122} {
+	for _, v := range testutil.AllVersions() {
+		// Make a copy of the version variable to use it concurrently
+		version := v
 		t.Run(fmt.Sprintf("for_version_%s", version), func(t *testing.T) {
 			t.Parallel()
 

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	"github.com/newrelic/infra-integrations-sdk/integration"
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/newrelic/nri-kubernetes/v2/internal/config"
 	"github.com/newrelic/nri-kubernetes/v2/internal/testutil"
 	"github.com/newrelic/nri-kubernetes/v2/src/definition"
 	"github.com/newrelic/nri-kubernetes/v2/src/ksm"
 	ksmClient "github.com/newrelic/nri-kubernetes/v2/src/ksm/client"
 	"github.com/newrelic/nri-kubernetes/v2/src/metric"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestScraper(t *testing.T) {
@@ -58,7 +59,7 @@ func TestScraper(t *testing.T) {
 			}
 
 			fakeK8s := fake.NewSimpleClientset(k8sData.Everything()...)
-			scraper, err := ksm.NewScraper(&config.Mock{
+			scraper, err := ksm.NewScraper(&config.Config{
 				KSM: config.KSM{
 					StaticURL: testServer.KSMEndpoint(),
 				},


### PR DESCRIPTION
Built on top of #281

Fake K8s object retrievers from the `testutil` package have been slightly modified to return objects by version, rather than sharing the same for all of them. This aligns better with the testdata tree. KSM and Kubelet scraper tests have been migrated accordingly.

Finally, during these tests, some bugs have been fixed and squashed, related to a missing `namespaceName` metric in HPA sample, and missing `LoadBalancerIP` in ServiceSample.
