### PR TITLE
Fix verbose setting a default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,7 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	// We need to assure that defaults have been set in order to bind env variables.
 	// https://github.com/spf13/viper/issues/584
 	v.SetDefault("clusterName", "cluster")
+	v.SetDefault("verbose", false)
 	v.SetDefault("nodeName", "node")
 	v.SetDefault("nodeIP", "node")
 	v.SetDefault("httpServerPort", 0)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	// https://github.com/spf13/viper/issues/584
 	v.SetDefault("clusterName", "cluster")
 	v.SetDefault("verbose", false)
+	v.SetDefault("networkRouteFile", "/proc/net/route")
 	v.SetDefault("nodeName", "node")
 	v.SetDefault("nodeIP", "node")
 	v.SetDefault("httpServerPort", 0)


### PR DESCRIPTION
It was not possible to set verbose as Env Var since we needed to set in in Viper first

Adding networkRouteFile as well 