### PR TITLE
Control plane Discoverer

### DIFF
--- a/src/controlplane/discoverer/discoverer.go
+++ b/src/controlplane/discoverer/discoverer.go
@@ -1,0 +1,96 @@
+package discoverer
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/newrelic/infra-integrations-sdk/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/newrelic/nri-kubernetes/v2/internal/config"
+	"github.com/newrelic/nri-kubernetes/v2/internal/discovery"
+)
+
+var ErrPodNotFound = errors.New("pod not found")
+
+// PodDiscoverer is used to discover control plane components.
+type PodDiscoverer interface {
+	// Discover returns a pod mathching the selector, namespaces and
+	// is in the same node if matchNode is true.
+	Discover(config.AutodiscoverControlPlane) (*corev1.Pod, error)
+}
+
+type Config struct {
+	PodListerer discovery.PodListerer
+	NodeName    string
+}
+
+type OptionFunc func(c *ControlplanePodDiscoverer) error
+
+// WithLogger returns an OptionFunc to change the logger from the default noop logger.
+func WithLogger(logger log.Logger) OptionFunc {
+	return func(c *ControlplanePodDiscoverer) error {
+		c.logger = logger
+		return nil
+	}
+}
+
+// ControlplanePodDiscoverer implements PodDiscoverer interface.
+type ControlplanePodDiscoverer struct {
+	Config
+	logger log.Logger
+}
+
+// New returns an ControlplanePodDiscoverer.
+func New(config Config, opts ...OptionFunc) (*ControlplanePodDiscoverer, error) {
+	c := &ControlplanePodDiscoverer{
+		logger: log.Discard,
+		Config: config,
+	}
+
+	for i, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, fmt.Errorf("applying option #%d: %w", i, err)
+		}
+	}
+
+	return c, nil
+}
+
+// Discover returns the first Pod matching the namespace and selector from the listed pods.
+// If MatchNode is true the Pod must be running on the same node to match.
+//
+// Errors returned by this function should be managed as severe and not related to the
+// autodiscover entry. No error is returned if no Pod has been discovered.
+func (c *ControlplanePodDiscoverer) Discover(ad config.AutodiscoverControlPlane) (*corev1.Pod, error) {
+	podLister, ok := c.PodListerer.Lister(ad.Namespace)
+	if !ok {
+		return nil, fmt.Errorf("pod lister for namespace: %s not found", ad.Namespace)
+	}
+
+	labelsSet, err := labels.ConvertSelectorToLabelsMap(ad.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector %q: %w", ad.Selector, err)
+	}
+
+	selector := labels.SelectorFromSet(labelsSet)
+
+	pods, err := podLister.List(selector)
+	if err != nil {
+		return nil, fmt.Errorf("listing pods with selector %q: %w", labelsSet, err)
+	}
+
+	c.logger.Debugf("%d pods found with labels %q", len(pods), ad.Selector)
+
+	for _, pod := range pods {
+		if ad.MatchNode && pod.Spec.NodeName != c.Config.NodeName {
+			c.logger.Debugf("Discarding pod: %s running outside the node", pod.Name)
+			continue
+		}
+		// first pod matching all conditions is returned.
+		return pod, nil
+	}
+
+	return nil, ErrPodNotFound
+}

--- a/src/controlplane/discoverer/discoverer_test.go
+++ b/src/controlplane/discoverer/discoverer_test.go
@@ -1,0 +1,210 @@
+package discoverer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/newrelic/infra-integrations-sdk/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/newrelic/nri-kubernetes/v2/internal/config"
+	"github.com/newrelic/nri-kubernetes/v2/internal/discovery"
+	"github.com/newrelic/nri-kubernetes/v2/src/controlplane/discoverer"
+)
+
+func Test_Discoverer_does_not_fail(t *testing.T) {
+	t.Parallel()
+
+	namespace := "testNamespace"
+	nodeName := "testNode"
+	selector := "foo=bar"
+
+	testCases := []struct {
+		name         string
+		pods         []*corev1.Pod
+		autodiscover config.AutodiscoverControlPlane
+		assert       func(*testing.T, *corev1.Pod, error)
+	}{
+		// Discover returns nil error and matching pod cases.
+		{
+			name: "when_single_pod_match_in_the_same_node",
+			autodiscover: config.AutodiscoverControlPlane{
+				Namespace: namespace,
+				Selector:  selector,
+				MatchNode: true,
+			},
+			pods: []*corev1.Pod{newPod("foo", namespace, selector, nodeName)},
+			assert: func(t *testing.T, p *corev1.Pod, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, newPod("foo", namespace, selector, nodeName), p)
+			},
+		},
+		{
+			name: "when_a_pod_matches_but_is_in_different_node_with_matchnode_false",
+			autodiscover: config.AutodiscoverControlPlane{
+				Namespace: namespace,
+				Selector:  selector,
+				MatchNode: false,
+			},
+			pods: []*corev1.Pod{newPod("foo", namespace, selector, "otherNode")},
+			assert: func(t *testing.T, p *corev1.Pod, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, newPod("foo", namespace, selector, "otherNode"), p)
+			},
+		},
+		{
+			name: "when_multiple_pods_match",
+			autodiscover: config.AutodiscoverControlPlane{
+				Namespace: namespace,
+				Selector:  selector,
+				MatchNode: true,
+			},
+			pods: []*corev1.Pod{
+				newPod("foo", namespace, selector, nodeName),
+				newPod("bar", namespace, selector, nodeName),
+				newPod("baz", namespace, selector, nodeName),
+			},
+			assert: func(t *testing.T, p *corev1.Pod, err error) {
+				assert.NoError(t, err)
+				assert.Contains(t, []string{"foo", "bar", "baz"}, p.Name)
+			},
+		},
+		{
+			name: "when_empty_selector",
+			autodiscover: config.AutodiscoverControlPlane{
+				Namespace: namespace,
+				Selector:  "",
+				MatchNode: true,
+			},
+			pods: []*corev1.Pod{newPod("foo", namespace, selector, nodeName)},
+			assert: func(t *testing.T, p *corev1.Pod, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, newPod("foo", namespace, selector, nodeName), p)
+			},
+		},
+		// Discover returns nil pod and nil error cases.
+		{
+			name: "when_a_pod_matches_but_is_in_different_node_with_matchnode_true",
+			autodiscover: config.AutodiscoverControlPlane{
+				Namespace: namespace,
+				Selector:  selector,
+				MatchNode: true,
+			},
+			pods: []*corev1.Pod{newPod("foo", namespace, selector, "otherNode")},
+			assert: func(t *testing.T, p *corev1.Pod, err error) {
+				assert.ErrorIs(t, err, discoverer.ErrPodNotFound)
+				assert.Nil(t, p)
+			},
+		},
+		{
+			name: "when_no_pod_matches_selector",
+			autodiscover: config.AutodiscoverControlPlane{
+				Namespace: namespace,
+				Selector:  "not-matching=selector",
+				MatchNode: true,
+			},
+			pods: []*corev1.Pod{newPod("foo", namespace, selector, nodeName)},
+			assert: func(t *testing.T, p *corev1.Pod, err error) {
+				assert.ErrorIs(t, err, discoverer.ErrPodNotFound)
+				assert.Nil(t, p)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		test := tc
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			k8sClient := fake.NewSimpleClientset()
+
+			for _, pod := range test.pods {
+				_, err := k8sClient.CoreV1().Pods(pod.Namespace).Create(
+					context.Background(),
+					pod,
+					metav1.CreateOptions{},
+				)
+				require.NoError(t, err)
+			}
+
+			pl, _ := discovery.NewNamespacePodListerer(
+				discovery.PodListererConfig{
+					Client:     k8sClient,
+					Namespaces: []string{test.autodiscover.Namespace},
+				},
+			)
+			pd, err := discoverer.New(
+				discoverer.Config{
+					PodListerer: pl,
+					NodeName:    nodeName,
+				},
+			)
+			require.NoError(t, err)
+
+			pod, err := pd.Discover(test.autodiscover)
+			test.assert(t, pod, err)
+		})
+	}
+}
+
+func Test_Discoverer_fails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("when_no_lister_is_found_for_the_namespace", func(t *testing.T) {
+		t.Parallel()
+
+		pl, _ := discovery.NewNamespacePodListerer(
+			discovery.PodListererConfig{
+				Client:     fake.NewSimpleClientset(),
+				Namespaces: []string{"foo"},
+			},
+		)
+		pd, err := discoverer.New(discoverer.Config{PodListerer: pl}, discoverer.WithLogger(log.Discard))
+		require.NoError(t, err)
+
+		_, err = pd.Discover(config.AutodiscoverControlPlane{
+			Namespace: "missing-namespace",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("when_selector_is_invalid", func(t *testing.T) {
+		t.Parallel()
+
+		pl, _ := discovery.NewNamespacePodListerer(
+			discovery.PodListererConfig{
+				Client:     fake.NewSimpleClientset(),
+				Namespaces: []string{"foo"},
+			},
+		)
+		pd, err := discoverer.New(discoverer.Config{PodListerer: pl})
+		require.NoError(t, err)
+
+		_, err = pd.Discover(config.AutodiscoverControlPlane{
+			Namespace: "foo",
+			Selector:  "=invalid=selector=",
+		})
+		assert.Error(t, err)
+	})
+}
+
+func newPod(name, namespace, selector, node string) *corev1.Pod {
+	labelsSet, _ := labels.ConvertSelectorToLabelsMap(selector)
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labelsSet,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node,
+		},
+	}
+}

--- a/src/controlplane/scraper.go
+++ b/src/controlplane/scraper.go
@@ -47,10 +47,6 @@ type ScraperOpt func(s *Scraper) error
 // WithLogger returns an OptionFunc to change the logger from the default noop logger.
 func WithLogger(logger log.Logger) ScraperOpt {
 	return func(s *Scraper) error {
-		if logger == nil {
-			return fmt.Errorf("logger canont be nil")
-		}
-
 		s.logger = logger
 
 		return nil
@@ -60,10 +56,8 @@ func WithLogger(logger log.Logger) ScraperOpt {
 // WithRestConfig returns an OptionFunc to change the restConfig from default empty config.
 func WithRestConfig(restConfig *rest.Config) ScraperOpt {
 	return func(s *Scraper) error {
-		if restConfig == nil {
-			return fmt.Errorf("restConfig canont be nil")
-		}
 		s.inClusterConfig = restConfig
+
 		return nil
 	}
 }


### PR DESCRIPTION
Moves pod discover logic to Discoverer, and add some corner cases testing.
Fixes #241