### PR TITLE
testutil/asserter: improve composability of exclude functions

### DIFF
--- a/internal/testutil/asserter/assert.go
+++ b/internal/testutil/asserter/assert.go
@@ -1,4 +1,4 @@
-package testutil
+package asserter
 
 import (
 	"strings"
@@ -7,90 +7,9 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/integration"
 
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter/exclude"
 	"github.com/newrelic/nri-kubernetes/v2/src/definition"
 )
-
-// ExcludeFunc is a function that returns true if a particular metric (spec) should be excluded from being asserted on
-// ent.
-// If an ExcludeFunc returns true for a given group, metric (spec) and entity, Asserter will not fail even if the metric
-// is not found.
-type ExcludeFunc func(group string, spec *definition.Spec, ent *integration.Entity) bool
-
-// Exclude returns an ExcludeFunc that returns true if all the supplied ExcludeFuncs return true.
-// Input ExcludeFuncs are evaluated in order, so this function makes easy to compose exclusion rules.
-func Exclude(funcs ...ExcludeFunc) ExcludeFunc {
-	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
-		for _, f := range funcs {
-			if !f(group, spec, ent) {
-				return false
-			}
-		}
-		return true
-	}
-}
-
-// ExcludeOptional returns an ExcludeFunc that excludes metrics marked as Optional.
-func ExcludeOptional() ExcludeFunc {
-	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
-		return spec.Optional
-	}
-}
-
-// ExcludeGroup returns an ExcludeFunc that will exclude a metric if group matches the supplied group.
-func ExcludeGroup(group string) ExcludeFunc {
-	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
-		return g == group
-	}
-}
-
-// ExcludeMetrics returns an ExcludeFunc that excludes the specified metric names.
-func ExcludeMetrics(metricNames ...string) ExcludeFunc {
-	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
-		for _, m := range metricNames {
-			if strings.EqualFold(spec.Name, m) {
-				return true
-			}
-		}
-
-		return false
-	}
-}
-
-// ExcludeMetricsGroup returns an ExcludeFunc that excludes the specified metric names belonging for the specified group.
-// Deprecated: Use Exclude(ExcludeGroup("group"), ExcludeMetrics("...")) instead.
-func ExcludeMetricsGroup(group string, metricNames ...string) ExcludeFunc {
-	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
-		for _, m := range metricNames {
-			if g == group && spec.Name == m {
-				return true
-			}
-		}
-
-		return false
-	}
-}
-
-// ExcludeDependent receives a map between a metric name and other metric names that depend on it, and returns an
-// ExcludeFunc that will exclude the dependencies if the dependant is not present.
-func ExcludeDependent(dependencies map[string][]string) ExcludeFunc {
-	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
-		for parent, children := range dependencies {
-			for _, ms := range ent.Metrics {
-				if _, hasParent := ms.Metrics[parent]; !hasParent {
-					continue
-				}
-
-				for _, child := range children {
-					if spec.Name == child {
-						return true
-					}
-				}
-			}
-		}
-
-		return false
-	}
-}
 
 // Asserter is a helper for checking whether an integration contains all the metrics defined in a specGroup.
 // It provides a chainable API, with each call returning a copy of the asserter. This way, successive calls to the
@@ -100,12 +19,12 @@ type Asserter struct {
 	entities       []*integration.Entity
 	specGroups     definition.SpecGroups
 	excludedGroups []string
-	exclude        []ExcludeFunc
+	exclude        []exclude.Func
 	silent         bool
 }
 
-// NewAsserter returns an empty asserter.
-func NewAsserter() Asserter {
+// New returns an empty asserter.
+func New() Asserter {
 	return Asserter{}
 }
 
@@ -121,12 +40,12 @@ func (a Asserter) On(entities []*integration.Entity) Asserter {
 	return a
 }
 
-// Excluding returns an asserter that will not fail for a missing metric for which any of the supplied ExcludeFunc
+// Excluding returns an asserter that will not fail for a missing metric for which any of the supplied Func
 // return true.
 // For ignoring whole spec groups, use ExcludingGroups instead.
 // Missing metrics are still logged, unless Silently is used.
-func (a Asserter) Excluding(excludeFuncs ...ExcludeFunc) Asserter {
-	exclude := make([]ExcludeFunc, len(a.exclude)+len(excludeFuncs))
+func (a Asserter) Excluding(excludeFuncs ...exclude.Func) Asserter {
+	exclude := make([]exclude.Func, len(a.exclude)+len(excludeFuncs))
 	copy(exclude, a.exclude)
 
 	a.exclude = append(a.exclude, excludeFuncs...)
@@ -155,7 +74,7 @@ func (a Asserter) Silently() Asserter {
 // Assert checks whether all metrics defined in the supplied groups are present, and fails the test if any is not.
 // Assert will fail the test if:
 // - No entity at all exists with a type matching a specGroup, unless this specGroup is ignored using ExcludingGroups.
-// - Any entity whose type matches a specGroup lacks any metric defined in the specGroup, unless any ExcludeFunc returns
+// - Any entity whose type matches a specGroup lacks any metric defined in the specGroup, unless any Func returns
 //   true for that particular groupName, metric, and entity.
 func (a Asserter) Assert(t *testing.T) {
 	t.Helper()
@@ -197,7 +116,7 @@ func (a Asserter) Assert(t *testing.T) {
 	}
 }
 
-// shouldExclude checks all configured ExcludeFunc in the asserter and returns true if any of them return true.
+// shouldExclude checks all configured Func in the asserter and returns true if any of them return true.
 func (a *Asserter) shouldExclude(group string, spec *definition.Spec, ent *integration.Entity) bool {
 	for _, exclusion := range a.exclude {
 		if exclusion(group, spec, ent) {

--- a/internal/testutil/asserter/assert.go
+++ b/internal/testutil/asserter/assert.go
@@ -98,7 +98,7 @@ func (a Asserter) Assert(t *testing.T) {
 
 		for _, spec := range group.Specs {
 			for _, entity := range entities {
-				if EntityContains(entity, spec.Name, spec.Type) {
+				if EntityMetricTypeIs(entity, spec.Name, spec.Type) {
 					continue
 				}
 
@@ -153,41 +153,41 @@ func entitiesFor(entities []*integration.Entity, pseudotype string) []*integrati
 // entityMetric is a helper function that returns the first metric from an entity that matches the given name.
 func entityMetric(e *integration.Entity, m string) interface{} {
 	for _, ms := range e.Metrics {
-		entityMetric, found := ms.Metrics[m]
-		if found {
-			return entityMetric
+		if entMetric, found := ms.Metrics[m]; found {
+			return entMetric
 		}
 	}
 
 	return nil
 }
 
-// EntityHas returns true if the specified entity has a metric of name m equal to value.
-func EntityHas(e *integration.Entity, m string, value interface{}) bool {
+// EntityMetricIs returns true if the specified entity has a metric named metricName equal to metricValue.
+func EntityMetricIs(e *integration.Entity, metricName string, metricValue interface{}) bool {
 	// Wildcard metrics are ignored.
 	// TODO: Improve this and check matching glob patterns.
-	if strings.HasSuffix(m, "*") {
+	if strings.HasSuffix(metricName, "*") {
 		return true
 	}
 
-	return entityMetric(e, m) == value
+	return entityMetric(e, metricName) == metricValue
 }
 
-// EntityContains returns true if supplied entity has metric m with type _similar_ to mType, false otherwise.
-func EntityContains(e *integration.Entity, m string, mType metric.SourceType) bool {
+// EntityMetricTypeIs returns true if supplied entity has metric named metricName with type _similar_ to metricType.
+func EntityMetricTypeIs(e *integration.Entity, metricName string, metricType metric.SourceType) bool {
 	// Wildcard metrics are ignored.
 	// TODO: Improve this and check matching glob patterns.
-	if strings.HasSuffix(m, "*") {
+	if strings.HasSuffix(metricName, "*") {
 		return true
 	}
 
-	em := entityMetric(e, m)
+	em := entityMetric(e, metricName)
 	if em == nil {
 		return false
 	}
 
-	// Check if metricType is an attribute but metric is not a string
 	_, isString := em.(string)
 
-	return (isString && mType == metric.ATTRIBUTE) || (!isString && mType != metric.ATTRIBUTE)
+	// Return true if metric is a string and metricType is metric.ATTRIBUTE, or
+	// if metric type is not a string and metricType is anything other than metric.ATTRIBUTE.
+	return (isString && metricType == metric.ATTRIBUTE) || (!isString && metricType != metric.ATTRIBUTE)
 }

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -74,6 +74,20 @@ func MetricsGroup(group string, metricNames ...string) Func {
 	}
 }
 
+// MetricEquals returns a Func that returns true if the entity a different metric has the specified value.
+// MetricEquals returns false if the specified metric is not found.
+func MetricEquals(metricName string, value interface{}) Func {
+	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
+		for _, ms := range ent.Metrics {
+			if val, ok := ms.Metrics[metricName]; ok {
+				return val == value
+			}
+		}
+
+		return false
+	}
+}
+
 // Dependent receives a map between a metric name and other metric names that depend on it, and returns an
 // Func that will exclude the dependencies if the dependent is not present.
 func Dependent(dependencies map[string][]string) Func {

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -1,0 +1,91 @@
+package exclude
+
+import (
+	"strings"
+
+	"github.com/newrelic/infra-integrations-sdk/integration"
+
+	"github.com/newrelic/nri-kubernetes/v2/src/definition"
+)
+
+// Func is a function that returns true if a particular metric (spec) should be excluded from being asserted on
+// ent.
+// If an Func returns true for a given group, metric (spec) and entity, Asserter will not fail even if the metric
+// is not found.
+type Func func(group string, spec *definition.Spec, ent *integration.Entity) bool
+
+// Exclude returns an Func that returns true if all the supplied ExcludeFuncs return true.
+// Input ExcludeFuncs are evaluated in order, so this function makes easy to compose exclusion rules.
+func Exclude(funcs ...Func) Func {
+	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
+		for _, f := range funcs {
+			if !f(group, spec, ent) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// Optional returns an Func that excludes metrics marked as Optional.
+func Optional() Func {
+	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
+		return spec.Optional
+	}
+}
+
+// Group returns an Func that will exclude a metric if group matches the supplied group.
+func Group(group string) Func {
+	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
+		return g == group
+	}
+}
+
+// Metrics returns an Func that excludes the specified metric names.
+func Metrics(metricNames ...string) Func {
+	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
+		for _, m := range metricNames {
+			if strings.EqualFold(spec.Name, m) {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// MetricsGroup returns an Func that excludes the specified metric names belonging for the specified group.
+// Deprecated: Use Exclude(Group("group"), Metrics("...")) instead.
+func MetricsGroup(group string, metricNames ...string) Func {
+	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
+		for _, m := range metricNames {
+			if g == group && spec.Name == m {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+// Dependent receives a map between a metric name and other metric names that depend on it, and returns an
+// Func that will exclude the dependencies if the dependent is not present.
+func Dependent(dependencies map[string][]string) Func {
+	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
+		for parent, children := range dependencies {
+			for _, ms := range ent.Metrics {
+				if _, hasParent := ms.Metrics[parent]; !hasParent {
+					continue
+				}
+
+				for _, child := range children {
+					if spec.Name == child {
+						return true
+					}
+				}
+			}
+		}
+
+		return false
+	}
+}

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -34,10 +34,16 @@ func Optional() Func {
 	}
 }
 
-// Group returns an Func that will exclude a metric if group matches the supplied group.
-func Group(group string) Func {
+// Groups returns an Func that will exclude a metric if group matches the supplied group.
+func Groups(groups ...string) Func {
 	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
-		return g == group
+		for _, group := range groups {
+			if g == group {
+				return true
+			}
+		}
+
+		return false
 	}
 }
 
@@ -55,7 +61,7 @@ func Metrics(metricNames ...string) Func {
 }
 
 // MetricsGroup returns an Func that excludes the specified metric names belonging for the specified group.
-// Deprecated: Use Exclude(Group("group"), Metrics("...")) instead.
+// Deprecated: Use Exclude(Groups("group"), Metrics("...")) instead.
 func MetricsGroup(group string, metricNames ...string) Func {
 	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
 		for _, m := range metricNames {

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -74,20 +74,6 @@ func MetricsGroup(group string, metricNames ...string) Func {
 	}
 }
 
-// MetricEquals returns a Func that returns true if the entity a different metric has the specified value.
-// MetricEquals returns false if the specified metric is not found.
-func MetricEquals(metricName string, value interface{}) Func {
-	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
-		for _, ms := range ent.Metrics {
-			if val, ok := ms.Metrics[metricName]; ok {
-				return val == value
-			}
-		}
-
-		return false
-	}
-}
-
 // Dependent receives a map between a metric name and other metric names that depend on it, and returns an
 // Func that will exclude the dependencies if the dependent is not present.
 func Dependent(dependencies map[string][]string) Func {

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -80,7 +80,7 @@ func Dependent(dependencies map[string][]string) Func {
 	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
 		for parent, children := range dependencies {
 			for _, ms := range ent.Metrics {
-				if _, hasParent := ms.Metrics[parent]; !hasParent {
+				if _, hasParent := ms.Metrics[parent]; hasParent {
 					continue
 				}
 

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -60,20 +60,6 @@ func Metrics(metricNames ...string) Func {
 	}
 }
 
-// MetricsGroup returns a Func that excludes the specified metric names belonging for the specified group.
-// Deprecated: Use Exclude(Groups("group"), Metrics("...")) instead.
-func MetricsGroup(group string, metricNames ...string) Func {
-	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
-		for _, m := range metricNames {
-			if g == group && spec.Name == m {
-				return true
-			}
-		}
-
-		return false
-	}
-}
-
 // Dependent receives a map between a metric name and other metric names that depend on it, and returns an
 // Func that will exclude the dependencies if the dependent is not present.
 func Dependent(dependencies map[string][]string) Func {

--- a/internal/testutil/asserter/exclude/exclude.go
+++ b/internal/testutil/asserter/exclude/exclude.go
@@ -10,11 +10,11 @@ import (
 
 // Func is a function that returns true if a particular metric (spec) should be excluded from being asserted on
 // ent.
-// If an Func returns true for a given group, metric (spec) and entity, Asserter will not fail even if the metric
+// If a Func returns true for a given group, metric (spec) and entity, Asserter will not fail even if the metric
 // is not found.
 type Func func(group string, spec *definition.Spec, ent *integration.Entity) bool
 
-// Exclude returns an Func that returns true if all the supplied ExcludeFuncs return true.
+// Exclude returns a Func that returns true if all the supplied ExcludeFuncs return true.
 // Input ExcludeFuncs are evaluated in order, so this function makes easy to compose exclusion rules.
 func Exclude(funcs ...Func) Func {
 	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
@@ -27,14 +27,14 @@ func Exclude(funcs ...Func) Func {
 	}
 }
 
-// Optional returns an Func that excludes metrics marked as Optional.
+// Optional returns a Func that excludes metrics marked as Optional.
 func Optional() Func {
 	return func(group string, spec *definition.Spec, ent *integration.Entity) bool {
 		return spec.Optional
 	}
 }
 
-// Groups returns an Func that will exclude a metric if group matches the supplied group.
+// Groups returns a Func that will exclude a metric if group matches the supplied group.
 func Groups(groups ...string) Func {
 	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
 		for _, group := range groups {
@@ -47,7 +47,7 @@ func Groups(groups ...string) Func {
 	}
 }
 
-// Metrics returns an Func that excludes the specified metric names.
+// Metrics returns a Func that excludes the specified metric names.
 func Metrics(metricNames ...string) Func {
 	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {
 		for _, m := range metricNames {
@@ -60,7 +60,7 @@ func Metrics(metricNames ...string) Func {
 	}
 }
 
-// MetricsGroup returns an Func that excludes the specified metric names belonging for the specified group.
+// MetricsGroup returns a Func that excludes the specified metric names belonging for the specified group.
 // Deprecated: Use Exclude(Groups("group"), Metrics("...")) instead.
 func MetricsGroup(group string, metricNames ...string) Func {
 	return func(g string, spec *definition.Spec, ent *integration.Entity) bool {

--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -50,9 +50,9 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 		Using(controlPlaneSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			testutil.ExcludeMetrics("controller-manager", excludeCM...),
-			testutil.ExcludeMetrics("etcd", excludeETCD...),
-			testutil.ExcludeMetrics("scheduler", excludeS...),
+			testutil.ExcludeMetricsGroup("controller-manager", excludeCM...),
+			testutil.ExcludeMetricsGroup("etcd", excludeETCD...),
+			testutil.ExcludeMetricsGroup("scheduler", excludeS...),
 		)
 
 	for _, v := range testutil.AllVersions() {
@@ -105,7 +105,7 @@ func Test_Scraper_Autodiscover_cp_component_after_start(t *testing.T) {
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			testutil.ExcludeMetrics("scheduler", excludeS...),
+			testutil.ExcludeMetricsGroup("scheduler", excludeS...),
 		)
 
 	testServer, err := testutil.LatestVersion().Server()
@@ -170,7 +170,7 @@ func Test_Scraper_external_endpoint(t *testing.T) {
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			testutil.ExcludeMetrics("scheduler", excludeS...),
+			testutil.ExcludeMetricsGroup("scheduler", excludeS...),
 		)
 
 	testServer, err := testutil.LatestVersion().Server()

--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -52,9 +52,18 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 		Using(controlPlaneSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			exclude.MetricsGroup("controller-manager", excludeCM...),
-			exclude.MetricsGroup("etcd", excludeETCD...),
-			exclude.MetricsGroup("scheduler", excludeS...),
+			exclude.Exclude(
+				exclude.Groups("controller-manager"),
+				exclude.Metrics(excludeCM...),
+			),
+			exclude.Exclude(
+				exclude.Groups("etcd"),
+				exclude.Metrics(excludeETCD...),
+			),
+			exclude.Exclude(
+				exclude.Groups("scheduler"),
+				exclude.Metrics(excludeS...),
+			),
 		)
 
 	for _, v := range testutil.AllVersions() {
@@ -107,7 +116,10 @@ func Test_Scraper_Autodiscover_cp_component_after_start(t *testing.T) {
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			exclude.MetricsGroup("scheduler", excludeS...),
+			exclude.Exclude(
+				exclude.Groups("scheduler"),
+				exclude.Metrics(excludeS...),
+			),
 		)
 
 	testServer, err := testutil.LatestVersion().Server()
@@ -172,7 +184,10 @@ func Test_Scraper_external_endpoint(t *testing.T) {
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			exclude.MetricsGroup("scheduler", excludeS...),
+			exclude.Exclude(
+				exclude.Groups("scheduler"),
+				exclude.Metrics(excludeS...),
+			),
 		)
 
 	testServer, err := testutil.LatestVersion().Server()

--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/newrelic/nri-kubernetes/v2/internal/config"
 	"github.com/newrelic/nri-kubernetes/v2/internal/testutil"
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter"
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter/exclude"
 	"github.com/newrelic/nri-kubernetes/v2/src/controlplane"
 	"github.com/newrelic/nri-kubernetes/v2/src/definition"
 	"github.com/newrelic/nri-kubernetes/v2/src/metric"
@@ -46,13 +48,13 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 	controlPlaneSpecs["scheduler"] = metric.SchedulerSpecs["scheduler"]
 	controlPlaneSpecs["api-server"] = metric.APIServerSpecs["api-server"]
 
-	asserter := testutil.NewAsserter().
+	asserter := asserter.New().
 		Using(controlPlaneSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			testutil.ExcludeMetricsGroup("controller-manager", excludeCM...),
-			testutil.ExcludeMetricsGroup("etcd", excludeETCD...),
-			testutil.ExcludeMetricsGroup("scheduler", excludeS...),
+			exclude.MetricsGroup("controller-manager", excludeCM...),
+			exclude.MetricsGroup("etcd", excludeETCD...),
+			exclude.MetricsGroup("scheduler", excludeS...),
 		)
 
 	for _, v := range testutil.AllVersions() {
@@ -101,11 +103,11 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 func Test_Scraper_Autodiscover_cp_component_after_start(t *testing.T) {
 	t.Parallel()
 
-	asserter := testutil.NewAsserter().
+	asserter := asserter.New().
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			testutil.ExcludeMetricsGroup("scheduler", excludeS...),
+			exclude.MetricsGroup("scheduler", excludeS...),
 		)
 
 	testServer, err := testutil.LatestVersion().Server()
@@ -166,11 +168,11 @@ func Test_Scraper_Autodiscover_cp_component_after_start(t *testing.T) {
 func Test_Scraper_external_endpoint(t *testing.T) {
 	t.Parallel()
 
-	asserter := testutil.NewAsserter().
+	asserter := asserter.New().
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
-			testutil.ExcludeMetricsGroup("scheduler", excludeS...),
+			exclude.MetricsGroup("scheduler", excludeS...),
 		)
 
 	testServer, err := testutil.LatestVersion().Server()

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -35,7 +35,7 @@ func TestScraper(t *testing.T) {
 			},
 			// The following HPA metrics operate in a true-or-NULL basis, and there won't be present if condition is
 			// false.
-			testutil.ExcludeMetrics("hpa", "isActive", "isAble", "isLimited"),
+			testutil.ExcludeMetricsGroup("hpa", "isActive", "isAble", "isLimited"),
 		)
 
 	// TODO: use testutil.AllVersions() when all versions are generated with datagen.sh.

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/newrelic/nri-kubernetes/v2/internal/config"
 	"github.com/newrelic/nri-kubernetes/v2/internal/testutil"
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter"
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter/exclude"
 	"github.com/newrelic/nri-kubernetes/v2/src/definition"
 	"github.com/newrelic/nri-kubernetes/v2/src/ksm"
 	ksmClient "github.com/newrelic/nri-kubernetes/v2/src/ksm/client"
@@ -20,7 +22,7 @@ import (
 
 func TestScraper(t *testing.T) {
 	// Create an asserter with the settings that are shared for all test scenarios.
-	asserter := testutil.NewAsserter().
+	asserter := asserter.New().
 		Using(metric.KSMSpecs).
 		Excluding(
 			// Exclude service.loadBalancerIP unless service is e2e-lb (specially crafted to have a fake one)
@@ -35,7 +37,7 @@ func TestScraper(t *testing.T) {
 			},
 			// The following HPA metrics operate in a true-or-NULL basis, and there won't be present if condition is
 			// false.
-			testutil.ExcludeMetricsGroup("hpa", "isActive", "isAble", "isLimited"),
+			exclude.MetricsGroup("hpa", "isActive", "isAble", "isLimited"),
 		)
 
 	// TODO: use testutil.AllVersions() when all versions are generated with datagen.sh.

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -37,7 +37,10 @@ func TestScraper(t *testing.T) {
 			},
 			// The following HPA metrics operate in a true-or-NULL basis, and there won't be present if condition is
 			// false.
-			exclude.MetricsGroup("hpa", "isActive", "isAble", "isLimited"),
+			exclude.Exclude(
+				exclude.Groups("hpa"),
+				exclude.Metrics("isActive", "isAble", "isLimited"),
+			),
 		)
 
 	// TODO: use testutil.AllVersions() when all versions are generated with datagen.sh.

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -34,8 +34,14 @@ func TestScraper(t *testing.T) {
 	asserter := asserter.New().
 		Using(metric.KubeletSpecs).
 		Excluding(
-			exclude.MetricsGroup("pod", commonMetricsToExclude...),
-			exclude.MetricsGroup("node", nodeMetricsToExclude...),
+			exclude.Exclude(
+				exclude.Groups("pod"),
+				exclude.Metrics(commonMetricsToExclude...),
+			),
+			exclude.Exclude(
+				exclude.Groups("node"),
+				exclude.Metrics(nodeMetricsToExclude...),
+			),
 			exclude.Optional(),
 			ExcludeMissingMetricsPendingPod,
 		)

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/newrelic/infra-integrations-sdk/integration"
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter"
+	"github.com/newrelic/nri-kubernetes/v2/internal/testutil/asserter/exclude"
 
 	"github.com/newrelic/nri-kubernetes/v2/src/definition"
 
@@ -29,13 +31,13 @@ func TestScraper(t *testing.T) {
 	nodeMetricsToExclude := append(commonMetricsToExclude, "allocatableCpuCoresUtilization", "allocatableMemoryUtilization")
 
 	// Create an asserter with the settings that are shared for all test scenarios.
-	asserter := testutil.NewAsserter().
+	asserter := asserter.New().
 		Using(metric.KubeletSpecs).
 		Excluding(
-			testutil.ExcludeMetricsGroup("pod", commonMetricsToExclude...),
-			testutil.ExcludeMetricsGroup("node", nodeMetricsToExclude...),
-			testutil.ExcludeOptional(),
-			excludeMissingMetricsPendingPod,
+			exclude.MetricsGroup("pod", commonMetricsToExclude...),
+			exclude.MetricsGroup("node", nodeMetricsToExclude...),
+			exclude.Optional(),
+			ExcludeMissingMetricsPendingPod,
 		)
 
 	for _, v := range testutil.AllVersions() {

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -32,10 +32,11 @@ func TestScraper(t *testing.T) {
 	asserter := testutil.NewAsserter().
 		Using(metric.KubeletSpecs).
 		Excluding(
-			testutil.ExcludeMetrics("pod", commonMetricsToExclude...),
-			testutil.ExcludeMetrics("node", nodeMetricsToExclude...),
+			testutil.ExcludeMetricsGroup("pod", commonMetricsToExclude...),
+			testutil.ExcludeMetricsGroup("node", nodeMetricsToExclude...),
 			testutil.ExcludeOptional(),
-		).Excluding(ExcludeMissingMetricsPendingPod)
+			excludeMissingMetricsPendingPod,
+		)
 
 	for _, v := range testutil.AllVersions() {
 		// Make a copy of the version variable to use it concurrently


### PR DESCRIPTION
This PR makes the `ExcludeFunc`s included with the `asserter` smaller and more composable. This is done by means of a very simple ExcludeFunc:

```go
// Exclude returns an ExcludeFunc that returns true if all the supplied ExcludeFuncs return true.
// Input ExcludeFuncs are evaluated in order, so this function makes easy to compose exclusion rules.
func Exclude(funcs ...ExcludeFunc) ExcludeFunc {
```

Which allow to chain other excludeFuncs:
```go
exclude.Exclude(
	// for pods...
	exclude.Groups("pod"),
	// that are waiting...
	func(_ string, _ *definition.Spec, ent *integration.Entity) bool {
		return asserter.EntityMetricIs(ent, "status", "waiting")
	},
	// exclude metrics defined in this `metricsToExcludeForPendingPods`
	exclude.Metrics(metricsToExcludeForPendingPods...),
),
```

Achieving complex things without the need to write that much boilerplate.