### PR TITLE
fix loadBalancerIP for services and namespaces for HPA

### DIFF
--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -600,7 +600,7 @@ var KSMSpecs = definition.SpecGroups{
 			},
 			{
 				Name:      "loadBalancerIP",
-				ValueFunc: prometheus.FromLabelValue("kube_service_status_load_balancer_ingress", "ip"),
+				ValueFunc: prometheus.FromLabelValue("kube_service_info", "load_balancer_ip"),
 				Type:      sdkMetric.ATTRIBUTE,
 				Optional:  true,
 			},
@@ -710,6 +710,7 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "desiredReplicas", ValueFunc: prometheus.FromValue("kube_hpa_status_desired_replicas"), Type: sdkMetric.GAUGE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_hpa_metadata_generation", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "label.*", ValueFunc: prometheus.InheritAllLabelsFrom("hpa", "kube_hpa_labels"), Type: sdkMetric.ATTRIBUTE},
+			// TODO: is* metrics will be either true or `NULL`, but never false if the condition is not reported. This is not ideal.
 			{Name: "isActive", ValueFunc: prometheus.FromValue("kube_hpa_status_condition_active")},
 			{Name: "isAble", ValueFunc: prometheus.FromValue("kube_hpa_status_condition_able")},
 			{Name: "isLimited", ValueFunc: prometheus.FromValue("kube_hpa_status_condition_limited")},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -708,7 +708,7 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "targetMetric", ValueFunc: prometheus.FromValue("kube_hpa_spec_target_metric"), Type: sdkMetric.GAUGE},
 			{Name: "currentReplicas", ValueFunc: prometheus.FromValue("kube_hpa_status_current_replicas"), Type: sdkMetric.GAUGE},
 			{Name: "desiredReplicas", ValueFunc: prometheus.FromValue("kube_hpa_status_desired_replicas"), Type: sdkMetric.GAUGE},
-			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_hpa_status_condition", "namespace"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_hpa_metadata_generation", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "label.*", ValueFunc: prometheus.InheritAllLabelsFrom("hpa", "kube_hpa_labels"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "isActive", ValueFunc: prometheus.FromValue("kube_hpa_status_condition_active")},
 			{Name: "isAble", ValueFunc: prometheus.FromValue("kube_hpa_status_condition_able")},


### PR DESCRIPTION
During the development of #282, we noticed the `loadBalancerIP` metric of the `K8sServiceSample` and `namespace` from `K8sHpaSample` were not being populated.

For the first case, this was being caused by attempting to get the `ip` label from the `kube_service_status_load_balancer_ingress` metric (from KSM). This metric will not be present if an ingress is not involved with the loadBalancer, so the label was not retrieved.

In the second case the root cause was very similar, retrieving the `namespace` label from the `kube_hpa_status_condition` metric which will not always be present.

This PR simply changes the source metric for those two attributes.