### PR TITLE
Refactor controlPlane getter.

### DIFF
--- a/cmd/kubernetes-static/main.go
+++ b/cmd/kubernetes-static/main.go
@@ -138,19 +138,3 @@ func main() {
 
 	fmt.Println()
 }
-
-type basicHTTPClient struct {
-	url        string
-	httpClient http.Client
-}
-
-func (b basicHTTPClient) Get(path string) (*http.Response, error) {
-	endpoint := fmt.Sprintf("%s%s", b.url, path)
-	log.Info("Getting: %s", endpoint)
-
-	return b.httpClient.Get(endpoint)
-}
-
-func (b basicHTTPClient) NodeIP() string {
-	return "localhost"
-}

--- a/src/client/interfaces.go
+++ b/src/client/interfaces.go
@@ -2,25 +2,7 @@ package client
 
 import (
 	"net/http"
-	"time"
 )
-
-// Discoverer allows discovering the endpoints from different services in the Kubernetes ecosystem.
-type Discoverer interface {
-	Discover(timeout time.Duration) (HTTPClient, error)
-}
-
-// MultiDiscoverer allows for discovery processes that return more
-// than a single HTTP client. For example, in one node we might query
-// more than one KSM instance, so we need two clients.
-type MultiDiscoverer interface {
-	Discover(timeout time.Duration) ([]HTTPClient, error)
-}
-
-// HTTPClient allows to connect to the discovered Kubernetes services
-type HTTPClient interface {
-	HTTPGetter
-}
 
 // HTTPGetter is an interface for HTTP client with, which should provide
 // scheme, port and hostname for the HTTP call.

--- a/src/controlplane/scraper.go
+++ b/src/controlplane/scraper.go
@@ -207,7 +207,7 @@ func (s *Scraper) externalEndpoint(c component) (*scrape.Job, error) {
 	// Entity key will be concatenated with host info (agent replace 'localhost' for hostname even in fw mode)
 	// example of etcd configured static (http://localhost:2381) entity key:'k8s:e2e-test:controlplane:etcd:minikube:2381'
 	grouper := grouper.New(
-		client,
+		client.MetricFamiliesGetFunc(),
 		c.Queries,
 		s.logger,
 		u.Host,
@@ -253,7 +253,7 @@ func (s *Scraper) autodiscover(c component) (*scrape.Job, error) {
 		}
 
 		grouper := grouper.New(
-			client,
+			client.MetricFamiliesGetFunc(),
 			c.Queries,
 			s.logger,
 			pod.Name,

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -70,6 +72,8 @@ func TestScraper(t *testing.T) {
 				K8s: fakeK8s,
 				KSM: ksmCli,
 			})
+
+			require.NoError(t, err)
 
 			i := testutil.NewIntegration(t)
 

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -71,6 +71,8 @@ func TestScraper(t *testing.T) {
 
 			i := testutil.NewIntegration(t)
 
+			require.NoError(t, err)
+
 			err = scraper.Run(i)
 			if err != nil {
 				t.Fatalf("running scraper: %v", err)

--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -163,7 +163,7 @@ func handleResponseWithFilter(resp *http.Response, queries []Query) ([]MetricFam
 	return metrics, nil
 }
 
-// MetricFamiliesGetFunc is the interface satisfied by Client.
+// MetricFamiliesGetFunc is the interface satisfied by prometheus Client.
 // TODO: This whole flow is too convoluted, we should refactor and rename this.
 type MetricFamiliesGetFunc interface {
 	// MetricFamiliesGetFunc returns a prometheus.FilteredFetcher configured to get KSM metrics from and endpoint.

--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -128,16 +128,6 @@ func valueFromPrometheus(metricType model.MetricType, metric *model.Metric) Valu
 	}
 }
 
-// Do is the main entry point. It runs queries against the Prometheus metrics provided by the endpoint.
-func Do(c client.HTTPGetter, endpoint string, queries []Query) ([]MetricFamily, error) {
-	resp, err := c.Get(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("fetching metrics from %q: %w", endpoint, err)
-	}
-
-	return handleResponseWithFilter(resp, queries)
-}
-
 func handleResponseWithFilter(resp *http.Response, queries []Query) ([]MetricFamily, error) {
 	if resp == nil {
 		return nil, fmt.Errorf("response cannot be nil")


### PR DESCRIPTION
The objective of this PR is making the control plane scraper more standard

Notice that it does not satisfy `prometheus.MetricFamiliesGetFunc`, since the url path is injected by the connector