### PR TITLE
main: use in-memory store for integration

### DIFF
--- a/cmd/kubernetes-static/main.go
+++ b/cmd/kubernetes-static/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	fakeK8s := fake.NewSimpleClientset(k8sData.Everything()...)
 
-	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
+	i, err := integration.New(integrationName, integrationVersion, integration.Args(&args), integration.InMemoryStore())
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -270,7 +270,7 @@ func createIntegrationWithHTTPSink(httpServerPort string) (*integration.Integrat
 		return nil, fmt.Errorf("creating HTTPSink: %w", err)
 	}
 
-	return integration.New(integrationName, integrationVersion, integration.Writer(h))
+	return integration.New(integrationName, integrationVersion, integration.Writer(h), integration.InMemoryStore())
 }
 
 func getK8sConfig(c *config.Config) (*rest.Config, error) {

--- a/src/definition/populate_test.go
+++ b/src/definition/populate_test.go
@@ -87,7 +87,7 @@ func testConfig(i *integration.Integration) *IntegrationPopulateConfig {
 }
 
 func TestIntegrationPopulator_CorrectValue(t *testing.T) {
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	expectedEntityData1, err := intgr.Entity("entity_id_1", "playground:test")
@@ -140,7 +140,7 @@ func TestIntegrationPopulator_PartialResult(t *testing.T) {
 		},
 	}
 
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	expectedEntityData1, err := intgr.Entity("entity_id_1", "playground:test")
@@ -183,7 +183,7 @@ func TestIntegrationPopulator_PartialResult(t *testing.T) {
 func TestIntegrationPopulator_EntitiesDataNotPopulated_EmptyMetricGroups(t *testing.T) {
 	metricGroupEmpty := RawGroups{}
 
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	expectedData := make([]*integration.Entity, 0)
@@ -198,7 +198,7 @@ func TestIntegrationPopulator_EntitiesDataNotPopulated_EmptyMetricGroups(t *test
 }
 
 func TestIntegrationPopulator_EntitiesDataNotPopulated_ErrorSettingEntities(t *testing.T) {
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	metricGroupEmptyEntityID := RawGroups{
@@ -234,7 +234,7 @@ func TestIntegrationPopulator_MetricsSetsNotPopulated_OnlyEntity(t *testing.T) {
 		},
 	}
 
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	expectedEntityData1, err := intgr.Entity("entity_id_1", "playground:test")
@@ -291,7 +291,7 @@ func TestIntegrationPopulator_EntityIDGenerator(t *testing.T) {
 		},
 	}
 
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	raw := RawGroups{
@@ -363,7 +363,7 @@ func TestIntegrationPopulator_EntityIDGeneratorFuncWithError(t *testing.T) {
 			},
 		},
 	}
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	config := testConfig(intgr)
@@ -418,7 +418,7 @@ func TestIntegrationPopulator_PopulateOnlySpecifiedGroups(t *testing.T) {
 	}
 
 	// Create a dummy integration, used only to create entities easily.
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	expectedEntityData1, err := intgr.Entity("testEntity11-generated", "playground:test")
@@ -525,7 +525,7 @@ func TestIntegrationPopulator_EntityTypeGeneratorFuncWithError(t *testing.T) {
 		},
 	}
 
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	config := testConfig(intgr)
@@ -545,7 +545,7 @@ func TestIntegrationPopulator_msTypeGuesserFuncWithError(t *testing.T) {
 		return "", fmt.Errorf("error setting event type")
 	}
 
-	intgr, err := integration.New("nr.test", "1.0.0")
+	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
 	expectedEntityData1, err := intgr.Entity("entity_id_1", "playground:test")

--- a/src/scrape/scrape_job_test.go
+++ b/src/scrape/scrape_job_test.go
@@ -156,7 +156,7 @@ func (tg *testGrouper) Group(definition.SpecGroups) (definition.RawGroups, *data
 }
 
 func TestPopulateK8s(t *testing.T) {
-	intgr, err := integration.New("test", "test")
+	intgr, err := integration.New("test", "test", integration.InMemoryStore())
 	assert.NoError(t, err)
 	intgr.Clear()
 


### PR DESCRIPTION
Since the integration is now long-running, it no longer needs to persist metrics for delta calculations or other tasks.
This removes the need to mount emptyDir volumes on `/tmp` for the integration container.

Open questions:
- ~Is `InMemoryStore` production ready, or meant for testing purposes only?~
- Will it behave properly in the long term, or will it leak resources?