### PR TITLE
ksm: wait for some time for endpoints to appear before erroring

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,10 @@ type KSM struct {
 	Namespace   string `mapstructure:"namespace"`
 	Distributed bool   `mapstructure:"distributed"`
 	Enabled     bool   `mapstructure:"enabled"`
+	Discovery   struct {
+		Wait    time.Duration `mapstructure:"retry"`
+		Retires int           `mapstructure:"retries"`
+	} `mapstructure:"discovery"`
 }
 
 type Kubelet struct {
@@ -92,6 +96,9 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	v.SetDefault("nodeName", "node")
 	v.SetDefault("nodeIP", "node")
 	v.SetDefault("httpServerPort", 0)
+
+	v.SetDefault("ksm.discovery.retry", 10*time.Second)
+	v.SetDefault("ksm.discovery.retries", 6)
 
 	v.SetEnvPrefix("NRI_KUBERNETES")
 	v.AutomaticEnv()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,7 +96,6 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	v.SetDefault("nodeName", "node")
 	v.SetDefault("nodeIP", "node")
 	v.SetDefault("httpServerPort", 0)
-
 	v.SetDefault("ksm.discovery.retry", 7*time.Second)
 	v.SetDefault("ksm.discovery.timeout", 60*time.Second)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,9 @@ type KSM struct {
 	Distributed bool   `mapstructure:"distributed"`
 	Enabled     bool   `mapstructure:"enabled"`
 	Discovery   struct {
-		Retry   time.Duration `mapstructure:"retry"`
+		// Wait BackoffDelay between discovery attempts.
+		BackoffDelay time.Duration `mapstructure:"backoffDelay"`
+		// Give up discovery and fail if Timeout has passed since first attempt.
 		Timeout time.Duration `mapstructure:"timeout"`
 	} `mapstructure:"discovery"`
 }
@@ -96,7 +98,7 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	v.SetDefault("nodeName", "node")
 	v.SetDefault("nodeIP", "node")
 	v.SetDefault("httpServerPort", 0)
-	v.SetDefault("ksm.discovery.retry", 7*time.Second)
+	v.SetDefault("ksm.discovery.backoffDelay", 7*time.Second)
 	v.SetDefault("ksm.discovery.timeout", 60*time.Second)
 
 	v.SetEnvPrefix("NRI_KUBERNETES")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,8 @@ type KSM struct {
 	Distributed bool   `mapstructure:"distributed"`
 	Enabled     bool   `mapstructure:"enabled"`
 	Discovery   struct {
-		Wait    time.Duration `mapstructure:"retry"`
-		Retires int           `mapstructure:"retries"`
+		Retry   time.Duration `mapstructure:"retry"`
+		Timeout time.Duration `mapstructure:"timeout"`
 	} `mapstructure:"discovery"`
 }
 
@@ -97,8 +97,8 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	v.SetDefault("nodeIP", "node")
 	v.SetDefault("httpServerPort", 0)
 
-	v.SetDefault("ksm.discovery.retry", 10*time.Second)
-	v.SetDefault("ksm.discovery.retries", 6)
+	v.SetDefault("ksm.discovery.retry", 7*time.Second)
+	v.SetDefault("ksm.discovery.timeout", 60*time.Second)
 
 	v.SetEnvPrefix("NRI_KUBERNETES")
 	v.AutomaticEnv()

--- a/internal/discovery/endpoints_discoverer.go
+++ b/internal/discovery/endpoints_discoverer.go
@@ -105,11 +105,11 @@ var ErrDiscoveryTimeout = errors.New("timeout discovering endpoints")
 // EndpointsDiscovererWithTimeout implements EndpointsDiscoverer with a retry mechanism if no endpoints are found.
 type EndpointsDiscovererWithTimeout struct {
 	EndpointsDiscoverer
-	Retry   time.Duration
-	Timeout time.Duration
+	BackoffDelay time.Duration
+	Timeout      time.Duration
 }
 
-// Discover will call poll the inner EndpointsDiscoverer every Retry seconds up to a max of Retries times until it
+// Discover will call poll the inner EndpointsDiscoverer every BackoffDelay seconds up to a max of Retries times until it
 // returns an error, or a non-empty list of endpoints.
 // If the max number of Retries is exceeded, it will return ErrDiscoveryTimeout.
 func (edt *EndpointsDiscovererWithTimeout) Discover() ([]string, error) {
@@ -124,7 +124,7 @@ func (edt *EndpointsDiscovererWithTimeout) Discover() ([]string, error) {
 			return endpoints, nil
 		}
 
-		time.Sleep(edt.Retry)
+		time.Sleep(edt.BackoffDelay)
 	}
 
 	return nil, ErrDiscoveryTimeout

--- a/internal/discovery/endpoints_discoverer.go
+++ b/internal/discovery/endpoints_discoverer.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -96,4 +97,34 @@ func (d *endpointsDiscoverer) Discover() ([]string, error) {
 	sort.Strings(hosts)
 
 	return hosts, nil
+}
+
+// ErrDiscoveryTimeout is returned by EndpointsDiscovererWithTimeout when discovery times out
+var ErrDiscoveryTimeout = errors.New("timeout discovering endpoints")
+
+// EndpointsDiscovererWithTimeout implements EndpointsDiscoverer with a retry mechanism if no endpoints are found.
+type EndpointsDiscovererWithTimeout struct {
+	EndpointsDiscoverer
+	Wait    time.Duration
+	Retries int
+}
+
+// Discover will call poll the inner EndpointsDiscoverer every Wait seconds up to a max of Retries times until it
+// returns an error, or a non-empty list of endpoints.
+// If the max number of Retries is exceeded, it will return ErrDiscoveryTimeout.
+func (edt *EndpointsDiscovererWithTimeout) Discover() ([]string, error) {
+	for try := 1; try <= edt.Retries; try++ {
+		endpoints, err := edt.EndpointsDiscoverer.Discover()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(endpoints) > 0 {
+			return endpoints, nil
+		}
+
+		time.Sleep(edt.Wait)
+	}
+
+	return nil, ErrDiscoveryTimeout
 }

--- a/internal/discovery/endpoints_discoverer_test.go
+++ b/internal/discovery/endpoints_discoverer_test.go
@@ -24,7 +24,7 @@ type testData struct {
 	result         []string
 }
 
-func Test_endpoints_discovery_whit(t *testing.T) {
+func Test_endpoints_discovery_with(t *testing.T) {
 	t.Parallel()
 
 	client := testclient.NewSimpleClientset(getFirstEndpoints(), getSecondEndpoints())

--- a/internal/discovery/endpoints_discoverer_timeout_test.go
+++ b/internal/discovery/endpoints_discoverer_timeout_test.go
@@ -1,0 +1,122 @@
+package discovery_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/newrelic/nri-kubernetes/v2/internal/discovery"
+)
+
+type fakeDiscoverer func() ([]string, error)
+
+func (fd fakeDiscoverer) Discover() ([]string, error) {
+	return fd()
+}
+
+func succeedDiscoverAfter(attempts int) fakeDiscoverer {
+	current := 0
+	return func() ([]string, error) {
+		if current >= attempts {
+			return []string{"success"}, nil
+		}
+
+		current++
+
+		return nil, nil
+	}
+}
+
+func Test_edt_forwards_errors(t *testing.T) {
+	t.Parallel()
+
+	innerErr := errors.New("inner error")
+	timeouter := discovery.EndpointsDiscovererWithTimeout{
+		EndpointsDiscoverer: fakeDiscoverer(func() ([]string, error) {
+			return nil, innerErr
+		}),
+		Wait:    0,
+		Retries: 1,
+	}
+
+	_, err := timeouter.Discover()
+	if !errors.Is(err, innerErr) {
+		t.Fatalf("unexpected error %v returned", err)
+	}
+}
+
+func Test_edt_forwards_endpoints(t *testing.T) {
+	t.Parallel()
+
+	innerList := []string{"foobar"}
+
+	timeouter := discovery.EndpointsDiscovererWithTimeout{
+		EndpointsDiscoverer: fakeDiscoverer(func() ([]string, error) {
+			return innerList, nil
+		}),
+		Wait:    0,
+		Retries: 1,
+	}
+
+	list, err := timeouter.Discover()
+	if err != nil {
+		t.Fatal("error should have been nil")
+	}
+
+	if !reflect.DeepEqual(innerList, list) {
+		t.Fatal("returned list is not equal")
+	}
+}
+
+func Test_edt(t *testing.T) {
+	t.Parallel()
+
+	type testEntry struct {
+		name        string
+		fd          fakeDiscoverer
+		wait        time.Duration
+		retries     int
+		expectedErr error
+	}
+
+	for _, entry := range []testEntry{
+		{
+			name:        "returns_at_once",
+			retries:     1,
+			fd:          succeedDiscoverAfter(0),
+			expectedErr: nil,
+		},
+		{
+			name:        "returns_within_threshold",
+			retries:     4,
+			fd:          succeedDiscoverAfter(3),
+			expectedErr: nil,
+		},
+		{
+			name:        "fails_not_in_threshold",
+			retries:     2,
+			fd:          succeedDiscoverAfter(3),
+			expectedErr: discovery.ErrDiscoveryTimeout,
+		},
+	} {
+		entry := entry
+
+		t.Run(entry.name, func(t *testing.T) {
+			timeouter := discovery.EndpointsDiscovererWithTimeout{
+				EndpointsDiscoverer: entry.fd,
+				Wait:                entry.wait,
+				Retries:             entry.retries,
+			}
+
+			_, err := timeouter.Discover()
+			if err == nil && entry.expectedErr != nil {
+				t.Fatal("should have errored")
+			}
+
+			if !errors.Is(err, entry.expectedErr) {
+				t.Fatalf("error is not the expected type: %v", err)
+			}
+		})
+	}
+}

--- a/internal/discovery/endpoints_discoverer_timeout_test.go
+++ b/internal/discovery/endpoints_discoverer_timeout_test.go
@@ -36,8 +36,8 @@ func Test_edt_forwards_errors(t *testing.T) {
 		EndpointsDiscoverer: fakeDiscoverer(func() ([]string, error) {
 			return nil, innerErr
 		}),
-		Retry:   0,
-		Timeout: 1 * time.Second,
+		BackoffDelay: 0,
+		Timeout:      1 * time.Second,
 	}
 
 	_, err := timeouter.Discover()
@@ -55,8 +55,8 @@ func Test_edt_forwards_endpoints(t *testing.T) {
 		EndpointsDiscoverer: fakeDiscoverer(func() ([]string, error) {
 			return innerList, nil
 		}),
-		Retry:   0,
-		Timeout: 1 * time.Second,
+		BackoffDelay: 0,
+		Timeout:      1 * time.Second,
 	}
 
 	list, err := timeouter.Discover()
@@ -108,7 +108,7 @@ func Test_edt(t *testing.T) {
 			t.Parallel()
 			timeouter := discovery.EndpointsDiscovererWithTimeout{
 				EndpointsDiscoverer: entry.fd,
-				Retry:               entry.wait,
+				BackoffDelay:        entry.wait,
 				Timeout:             entry.timeout,
 			}
 

--- a/src/ksm/scraper.go
+++ b/src/ksm/scraper.go
@@ -185,8 +185,8 @@ func (s *Scraper) buildDiscoverer() (discovery.EndpointsDiscoverer, error) {
 	return &discovery.EndpointsDiscovererWithTimeout{
 		EndpointsDiscoverer: discoverer,
 
-		Wait:    s.config.KSM.Discovery.Wait,
-		Retries: s.config.KSM.Discovery.Retires,
+		Retry:   s.config.KSM.Discovery.Retry,
+		Timeout: s.config.KSM.Discovery.Timeout,
 	}, nil
 }
 

--- a/src/ksm/scraper.go
+++ b/src/ksm/scraper.go
@@ -185,8 +185,8 @@ func (s *Scraper) buildDiscoverer() (discovery.EndpointsDiscoverer, error) {
 	return &discovery.EndpointsDiscovererWithTimeout{
 		EndpointsDiscoverer: discoverer,
 
-		Retry:   s.config.KSM.Discovery.Retry,
-		Timeout: s.config.KSM.Discovery.Timeout,
+		BackoffDelay: s.config.KSM.Discovery.BackoffDelay,
+		Timeout:      s.config.KSM.Discovery.Timeout,
 	}, nil
 }
 

--- a/src/ksm/scraper.go
+++ b/src/ksm/scraper.go
@@ -32,9 +32,9 @@ type Providers struct {
 
 // Scraper takes care of getting metrics from an autodiscovered KSM instance.
 type Scraper struct {
-	logger *log.Logger
-	config *config.Config
 	Providers
+	logger              *log.Logger
+	config              *config.Config
 	k8sVersion          *version.Info
 	endpointsDiscoverer discovery.EndpointsDiscoverer
 	servicesLister      listersv1.ServiceLister
@@ -177,7 +177,17 @@ func (s *Scraper) buildDiscoverer() (discovery.EndpointsDiscoverer, error) {
 		dc.Port = s.config.KSM.Port
 	}
 
-	return discovery.NewEndpointsDiscoverer(dc)
+	discoverer, err := discovery.NewEndpointsDiscoverer(dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &discovery.EndpointsDiscovererWithTimeout{
+		EndpointsDiscoverer: discoverer,
+
+		Wait:    s.config.KSM.Discovery.Wait,
+		Retries: s.config.KSM.Discovery.Retires,
+	}, nil
 }
 
 func (s *Scraper) ksmURLs() ([]string, error) {


### PR DESCRIPTION
A new `EndpointsDiscoverer` implementation, `EndpointsDiscovererWithTimeout` has been added. EndpointsDiscovererWithTimeout wraps another EndpointsDiscoverer adding a simple retry logic on top.

Main motivation for this change is to have the KSM pod no crash if KSM has not been deployed, although it can also be useful to make it more tolerant for other situations like KSM being migrated.