### PR TITLE
Dockerfile: add curl and bind-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.14
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --upgrade && apk add --no-cache tini=0.19.0-r0
+RUN apk add --no-cache --upgrade && apk add --no-cache tini=0.19.0-r0 curl bind-tools
 
 ADD --chmod=755 bin/nri-kubernetes-${TARGETOS}-${TARGETARCH} /var/db/newrelic-infra/newrelic-integrations/bin/
 


### PR DESCRIPTION
`curl` and `dig` are basic troubleshooting tools that allows customers and developers to debug errors connecting to several of the APIs the integration needs to work.
In unprivileged mode, or with `readOnlyFilesystem: true` it will be impossible for users to install these tools after the image has been deployed in the cluster, hence the need for having them beforehand.