### PR TITLE
Update dependabot.yml to skip e2e

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,22 @@ updates:
     open-pull-requests-limit: 3
     ignore:
       - dependency-name: "k8s.io/*"
+    labels:
+      - dependencies
+      - ci/skip-e2e 
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 2
+    labels: 
+      - ci/skip-e2e
+      - dependencies
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 2
+    labels: 
+      - ci/skip-e2e
+      - dependencies


### PR DESCRIPTION
Since external PRs do not have access to secrets they fail.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#labels