### PR TITLE
ci/e2e: add 1.23.3 to test matrix, upgrade patches for other versions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Latest patch version can be found in https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
         # Some versions might not be available yet in https://storage.googleapis.com/kubernetes-release/release/v1.X.Y/bin/linux/amd64/kubelet
-        k8sVersion: [ "v1.22.3", "v1.21.4", "v1.20.10", "v1.19.14", "v1.18.20", "v1.17.17", "v1.16.15" ]
+        k8sVersion: [ "1.23.3", "v1.22.6", "v1.21.9", "v1.20.15", "v1.19.16", "v1.18.20", "v1.17.17", "v1.16.15" ]
     env:
       DOCKER_BUILDKIT: '1' # Setting DOCKER_BUILDKIT=1 ensures TARGETOS and TARGETARCH are populated
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,8 @@ jobs:
         # Latest patch version can be found in https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
         # Some versions might not be available yet in https://storage.googleapis.com/kubernetes-release/release/v1.X.Y/bin/linux/amd64/kubelet
         k8sVersion: [ "1.23.2", "v1.22.6", "v1.21.9", "v1.20.15", "v1.19.16", "v1.18.20", "v1.17.17", "v1.16.15" ]
+    # 1.23 support is still a work in progress
+    continue-on-error: ${{ startsWith(matrix.k8sVersion, "1.23") }}
     env:
       DOCKER_BUILDKIT: '1' # Setting DOCKER_BUILDKIT=1 ensures TARGETOS and TARGETARCH are populated
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Latest patch version can be found in https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
         # Some versions might not be available yet in https://storage.googleapis.com/kubernetes-release/release/v1.X.Y/bin/linux/amd64/kubelet
-        k8sVersion: [ "1.23.3", "v1.22.6", "v1.21.9", "v1.20.15", "v1.19.16", "v1.18.20", "v1.17.17", "v1.16.15" ]
+        k8sVersion: [ "1.23.2", "v1.22.6", "v1.21.9", "v1.20.15", "v1.19.16", "v1.18.20", "v1.17.17", "v1.16.15" ]
     env:
       DOCKER_BUILDKIT: '1' # Setting DOCKER_BUILDKIT=1 ensures TARGETOS and TARGETARCH are populated
     steps:


### PR DESCRIPTION
Pretty much as the title says.