### PR TITLE
scrape/job: log recoverable errors as Trace

### DIFF
--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -68,6 +68,15 @@ func main() {
 		logger.SetLevel(log.DebugLevel)
 	}
 
+	if c.LogLevel != "" {
+		level, err := log.ParseLevel(c.LogLevel)
+		if err != nil {
+			log.Warnf("Cannot parse log level %q: %v", c.LogLevel, err)
+		} else {
+			logger.SetLevel(level)
+		}
+	}
+
 	i, err := createIntegrationWithHTTPSink(c)
 	if err != nil {
 		logger.Errorf("creating integration with http sink: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ const (
 
 type Config struct {
 	Verbose        bool          `mapstructure:"verbose"`
+	LogLevel       string        `mapstructure:"logLevel"`
 	ClusterName    string        `mapstructure:"clusterName"`
 	KubeconfigPath string        `mapstructure:"kubeconfigPath"`
 	NodeIP         string        `mapstructure:"nodeIP"`

--- a/src/scrape/scrape_job.go
+++ b/src/scrape/scrape_job.go
@@ -44,7 +44,7 @@ func (s *Job) Populate(
 			}
 		}
 
-		logger.Warnf("%s", errs)
+		logger.Tracef("%s", errs)
 	}
 
 	config := &definition.IntegrationPopulateConfig{


### PR DESCRIPTION
So-called recoverable "errors" are expected to happen, as it is nearly impossible for a cluster to have all possible metrics available.

This PR changes log level of these errors to `Trace`.