### PR TITLE
Dockerfile: simplify binary path, ensure 755 permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@ FROM alpine:3.15.0
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --upgrade && apk add --no-cache tini=0.19.0-r0 curl bind-tools
+RUN apk add --no-cache --upgrade && apk add --no-cache tini curl bind-tools
 
-ADD --chmod=755 bin/nri-kubernetes-${TARGETOS}-${TARGETARCH} /var/db/newrelic-infra/newrelic-integrations/bin/
+ADD bin/nri-kubernetes-${TARGETOS}-${TARGETARCH} /bin/
 
-RUN mv /var/db/newrelic-infra/newrelic-integrations/bin/nri-kubernetes-${TARGETOS}-${TARGETARCH} \
-       /var/db/newrelic-infra/newrelic-integrations/bin/nri-kubernetes
+RUN mv /bin/nri-kubernetes-${TARGETOS}-${TARGETARCH} /bin/nri-kubernetes && \
+    chmod 755 /bin/nri-kubernetes
 
 # creating the nri-agent user used only in unprivileged mode
 RUN addgroup -g 2000 nri-agent && adduser -D -u 1000 -G nri-agent nri-agent
 
 USER nri-agent
 
-ENTRYPOINT ["/sbin/tini", "--", "/var/db/newrelic-infra/newrelic-integrations/bin/nri-kubernetes"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/nri-kubernetes"]


### PR DESCRIPTION
Since the integration is now a standalone binary, there is no real reason for the binary to be placed in such a complicated path.

As for the chmod, `ADD --chmod` is supported only when using BuildKit. Since we already need to perform a `RUN mv`, using a `chmod` command instead removes the BuildKit requirement while not adding any extra layer to he image.