### PR TITLE
fix(ci/cd): extra char in pipline command

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Push pre-release images
         if: ${{ github.event.release.prerelease }}
         run: |
-          DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre"
+          DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre
           docker buildx build --push --platform=$DOCKER_PLATFORMS \
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             .


### PR DESCRIPTION
A small bug was introduced in the ci/cd pipeline, it affect for sure also [nri-metadata-injection](https://github.com/newrelic/k8s-metadata-injection/blob/805f1c8993ee497dc57fb6621b34f594fdf218cf/.github/workflows/release-integration.yml#L76) and [metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/blob/24fd202c0b0699ebf2bc326e0df20876f3f24885/.github/workflows/release-integration.yml#L78)