### PR TITLE
Release charts also from v2 branch

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - "main"
+      - main
+      - v2
 
 jobs:
   e2eTests:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v2
 
 jobs:
   build:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v2
 
 jobs:
 #   Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo


### PR DESCRIPTION
This allows emptying `helm-charts` repository from legacy charts.

The helm chart for `v2` is waiting in the PR #415