### PR TITLE
Remove v2 from the main pipelines

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,10 +2,11 @@ name: E2E over minikube
 
 on:
   pull_request:
+    branches-ignore:
+      - v2
   push:
     branches:
       - main
-      - v2
 
 jobs:
   e2eTests:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -1,10 +1,11 @@
 name: Push/PR pipeline
 on:
   pull_request:
+    branches-ignore:
+      - v2
   push:
     branches:
       - main
-      - v2
 
 jobs:
   build:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v2
 
 jobs:
 #   Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo


### PR DESCRIPTION
I added to the pipelines in #414 the possibility to release charts from the `v2` branch but I realized that GitHub ignores workflows that are outside its branch.

I created PR #423 to add this to the `v2` branch and this PR to clean the `main` branch.