### PR TITLE
[chart] Add pixie self monitoring

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.4.0
+version: 3.5.0
 appVersion: 3.1.1
 
 dependencies:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -136,6 +136,7 @@ integrations that you have configured.
 | customSecretLicenseKey | string | `""` | In case you don't want to have the license key in you values, this allows you to point to which secret key is the license key located. Can be configured also with `global.customSecretLicenseKey` |
 | customSecretName | string | `""` | In case you don't want to have the license key in you values, this allows you to point to a user created secret to get the key from there. Can be configured also with `global.customSecretName` |
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
+| enableProcessMetrics | bool | `true` | Collect detailed metrics from processes running in the host. This defaults to true for accounts created before July 20, 2020. ref: https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120 |
 | fedramp.enabled | bool | `false` | Enables FedRAMP. Can be configured also with `global.fedramp.enabled` |
 | fullnameOverride | string | `""` | Override the full name of the release |
 | hostNetwork | bool | `false` | Sets pod's hostNetwork. Can be configured also with `global.hostNetwork` |
@@ -179,6 +180,7 @@ integrations that you have configured.
 | proxy | string | `""` | Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`. Can be configured also with `global.proxy` |
 | rbac.create | bool | `true` | Whether the chart should automatically create the RBAC objects required to run. |
 | rbac.pspEnabled | bool | `false` | Whether the chart should create Pod Security Policy objects. |
+| selfMonitoring.pixie.enabled | bool | `true` | Enables the Pixie Health Check nri-flex config. This Flex config performs periodic checks of the Pixie /healthz and /statusz endpoints exposed by the Pixie Cloud Connector. A status for each endpoint is sent to New Relic in a pixieHealthCheck event. |
 | serviceAccount | object | See `values.yaml` | Settings controlling ServiceAccount creation. |
 | serviceAccount.create | bool | `true` | Whether the chart should automatically create the ServiceAccount objects required to run. |
 | strategy | object | `type: Recreate` | Update strategy for the deployed Deployments. |

--- a/charts/newrelic-infrastructure/templates/kubelet/integrations-configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/integrations-configmap.yaml
@@ -34,4 +34,39 @@ data:
   {{- tpl ($v | toYaml) $ | nindent 4 -}}
   {{- end }}
   {{- end }}
+
+  {{- /* This template will add and template the integrations in the old .Values.integrations_config */}}
   {{- include "newrelic.compatibility.integrations" . | nindent 2 }}
+
+  {{- /* This template will add Pixie Health check to the integrations */}}
+  {{- if .Values.selfMonitoring.pixie.enabled }}
+  pixie-health-check.yaml: |
+    ---
+    # This Flex config performs periodic checks of the Pixie
+    # /healthz and /statusz endpoints exposed by the Pixie Cloud Connector.
+    # A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
+    #
+    # If Pixie is not installed in the cluster, no events will be generated.
+    # This can also be disabled with enablePixieHealthCheck: false in the values.yaml file.
+    discovery:
+      command:
+        exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
+        match:
+          label.name: vizier-cloud-connector
+    integrations:
+      - name: nri-flex
+        interval: 60s
+        config:
+          name: pixie-health-check
+          apis:
+            - event_type: pixieHealth
+              commands:
+                - run: curl --insecure -s https://${discovery.ip}:50800/healthz | xargs | awk '{print "cloud_connector_health:"$1}'
+                  split_by: ":"
+              merge: pixieHealthCheck
+            - event_type: pixieStatus
+              commands:
+                - run: curl --insecure -s https://${discovery.ip}:50800/statusz | awk '{if($1 == ""){ print "cloud_connector_status:OK" } else { print "cloud_connector_status:"$1 }}'
+                  split_by: ":"
+              merge: pixieHealthCheck
+  {{- end }}

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -509,12 +509,11 @@ integrations: {}
 #        labels:
 #          env: test
 
-# Collect detailed metrics from processes running in the host.
-# @default -- [True only for accounts created before July 20, 2020.](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120)
-# enableProcessMetrics: false
-
-# Send data to New Relic Staging. Requires an staging-specific License Key.
-# nrStaging: false
+# -- (bool) Collect detailed metrics from processes running in the host.
+# This defaults to true for accounts created before July 20, 2020.
+# ref: https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1120
+# @default -- `true`
+enableProcessMetrics:
 
 # Prefix nodes display name with cluster to reduce chances of collisions
 # prefixDisplayNameWithCluster: false
@@ -524,6 +523,13 @@ integrations: {}
 #  and prefixDisplayNameWithCluster is not set to true.
 # 'false' will use the host name as the name for the "host".
 # useNodeNameAsDisplayName: true
+
+selfMonitoring:
+  pixie:
+    # selfMonitoring.pixie.enabled -- Enables the Pixie Health Check nri-flex config.
+    # This Flex config performs periodic checks of the Pixie /healthz and /statusz endpoints exposed by the Pixie
+    # Cloud Connector. A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
+    enabled: true
 
 
 # -- Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`. Can be configured also with `global.proxy`


### PR DESCRIPTION
The functionality to self-monitor pixie was added while `v2` was in beta on the `v2` chart and we did not port that functionality to the `v3` chart.

This should add that lost feature again.