### PR TITLE
chart: add -scraper suffix to pod names

### DIFF
--- a/charts/newrelic-infrastructure/Chart.lock
+++ b/charts/newrelic-infrastructure/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://helm-charts.newrelic.com
   version: 1.0.4
 digest: sha256:6aeb4d18a5b6c9ee130a010b6f71f6af3a003d52d90e17a64ef58e6649e0388f
-generated: "2022-05-05T18:29:49.912421427Z"
+generated: "2022-05-13T14:57:16.114864693+02:00"

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.6.2
+version: 3.7.0
 appVersion: 3.3.1
 
 dependencies:

--- a/charts/newrelic-infrastructure/templates/controlplane/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/controlplane/_naming.tpl
@@ -1,8 +1,8 @@
 {{- /* Naming helpers*/ -}}
 {{- define "nriKubernetes.controlplane.fullname" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "controlplane") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "controlplane-scraper") -}}
 {{- end -}}
 
 {{- define "nriKubernetes.controlplane.fullname.agent" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent-controlplane") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "controlplane-agent") -}}
 {{- end -}}

--- a/charts/newrelic-infrastructure/templates/ksm/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/ksm/_naming.tpl
@@ -1,8 +1,8 @@
 {{- /* Naming helpers*/ -}}
 {{- define "nriKubernetes.ksm.fullname" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "ksm") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "ksm-scraper") -}}
 {{- end -}}
 
 {{- define "nriKubernetes.ksm.fullname.agent" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent-ksm") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "ksm-agent") -}}
 {{- end -}}

--- a/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
@@ -1,10 +1,10 @@
 {{- /* Naming helpers*/ -}}
 {{- define "nriKubernetes.kubelet.fullname" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet-scraper") -}}
 {{- end -}}
 
 {{- define "nriKubernetes.kubelet.fullname.agent" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent-kubelet") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet-agent") -}}
 {{- end -}}
 
 {{- define "nriKubernetes.kubelet.fullname.integrations" -}}

--- a/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
@@ -1,10 +1,10 @@
 {{- /* Naming helpers*/ -}}
 {{- define "nriKubernetes.kubelet.fullname" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet-scraper") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet-node-scraper") -}}
 {{- end -}}
 
 {{- define "nriKubernetes.kubelet.fullname.agent" -}}
-{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet-agent") -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet-node-agent") -}}
 {{- end -}}
 
 {{- define "nriKubernetes.kubelet.fullname.integrations" -}}

--- a/charts/newrelic-infrastructure/tests/podName_test.yaml
+++ b/charts/newrelic-infrastructure/tests/podName_test.yaml
@@ -20,15 +20,15 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-nrk8s-ksm
+          value: RELEASE-NAME-nrk8s-ksm-scraper
         template: templates/ksm/deployment.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-nrk8s-controlplane
+          value: RELEASE-NAME-nrk8s-controlplane-scraper
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-nrk8s-kubelet
+          value: RELEASE-NAME-nrk8s-kubelet-scraper
         template: templates/kubelet/daemonset.yaml
   - it: name is overridden as expected
     set:
@@ -38,13 +38,13 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: fno-ksm
+          value: fno-ksm-scraper
         template: templates/ksm/deployment.yaml
       - equal:
           path: metadata.name
-          value: fno-controlplane
+          value: fno-controlplane-scraper
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: metadata.name
-          value: fno-kubelet
+          value: fno-kubelet-scraper
         template: templates/kubelet/daemonset.yaml

--- a/charts/newrelic-infrastructure/tests/podName_test.yaml
+++ b/charts/newrelic-infrastructure/tests/podName_test.yaml
@@ -28,7 +28,7 @@ tests:
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-nrk8s-kubelet-scraper
+          value: RELEASE-NAME-nrk8s-kubelet-node-scraper
         template: templates/kubelet/daemonset.yaml
   - it: name is overridden as expected
     set:
@@ -46,5 +46,5 @@ tests:
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: metadata.name
-          value: fno-kubelet-scraper
+          value: fno-kubelet-node-scraper
         template: templates/kubelet/daemonset.yaml


### PR DESCRIPTION
As previously discussed, the overly simplified names were causing some confusion among users. The `-scraper` suffix should hopefully help to make more obvious that these pods are clients, rather than servers.