### PR TITLE
health: add liveness server

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -38,7 +38,3 @@ keywords:
   - infrastructure
   - newrelic
   - monitoring
-
-annotations:
-  artifacthub.io/changes: |
-    - Added liveness probe

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.5.1
+version: 3.6.0
 appVersion: 3.2.0
 
 dependencies:
@@ -38,3 +38,7 @@ keywords:
   - infrastructure
   - newrelic
   - monitoring
+
+annotations:
+  artifacthub.io/changes: |
+    - Added liveness probe

--- a/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
@@ -80,6 +80,12 @@ spec:
             - name: "NRI_KUBERNETES_VERBOSE"
               value: {{ include "newrelic.common.verboseLog.valueAsBoolean" . | quote }}
 
+            {{- if include "nriKubernetes.controlPlane.hostNetwork" . }}
+            {{/* If we are running in hostNetwork, do not set up the health probe */}}
+            - name: "NRI_KUBERNETES_HEALTH_ADDRESS"
+              value: ""
+            {{- end }}
+
             - name: "NRI_KUBERNETES_NODENAME"
               valueFrom:
                 fieldRef:
@@ -97,6 +103,18 @@ spec:
           {{- with .Values.controlPlane.extraEnvFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
+
+          {{- if not (include "nriKubernetes.controlPlane.hostNetwork" .) }}
+          ports:
+            - containerPort: 8999
+          startupProbe:
+            periodSeconds: 30
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8999
+          {{- end }}
+
           volumeMounts:
             - name: nri-kubernetes-config
               mountPath: /etc/newrelic-infra/nri-kubernetes.yml

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -85,6 +85,14 @@ spec:
           {{- with .Values.ksm.extraEnvFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
+          ports:
+            - containerPort: 8999
+          startupProbe:
+            periodSeconds: 30
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8999
           volumeMounts:
             - name: nri-kubernetes-config
               mountPath: /etc/newrelic-infra/nri-kubernetes.yml

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -73,6 +73,12 @@ spec:
             - name: "NRI_KUBERNETES_VERBOSE"
               value: {{ include "newrelic.common.verboseLog.valueAsBoolean" . | quote }}
 
+            {{- if include "newrelic.common.hostNetwork" . }}
+            {{/* If we are running in hostNetwork, do not set up the health probe */}}
+            - name: "NRI_KUBERNETES_HEALTH_ADDRESS"
+              value: ""
+            {{- end }}
+
             - name: "NRI_KUBERNETES_NODENAME"
               valueFrom:
                 fieldRef:
@@ -85,6 +91,7 @@ spec:
           {{- with .Values.ksm.extraEnvFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- if not (include "newrelic.common.hostNetwork" .) }}
           ports:
             - containerPort: 8999
           startupProbe:
@@ -93,6 +100,7 @@ spec:
             httpGet:
               path: /health
               port: 8999
+          {{- end }}
           volumeMounts:
             - name: nri-kubernetes-config
               mountPath: /etc/newrelic-infra/nri-kubernetes.yml

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -74,6 +74,12 @@ spec:
             - name: "NRI_KUBERNETES_VERBOSE"
               value: {{ include "newrelic.common.verboseLog.valueAsBoolean" . | quote }}
 
+            {{- if include "newrelic.common.hostNetwork" . }}
+            {{/* If we are running in hostNetwork, do not set up the health probe */}}
+            - name: "NRI_KUBERNETES_HEALTH_ADDRESS"
+              value: ""
+            {{- end }}
+
             - name: "NRI_KUBERNETES_NODENAME"
               valueFrom:
                 fieldRef:
@@ -92,6 +98,7 @@ spec:
           {{- with .Values.kubelet.extraEnvFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- if not (include "newrelic.common.hostNetwork" .) }}
           ports:
             - containerPort: 8999
           startupProbe:
@@ -100,6 +107,7 @@ spec:
             httpGet:
               path: /health
               port: 8999
+          {{- end }}
           volumeMounts:
             - name: nri-kubernetes-config
               mountPath: /etc/newrelic-infra/nri-kubernetes.yml

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -92,6 +92,14 @@ spec:
           {{- with .Values.kubelet.extraEnvFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
+          ports:
+            - containerPort: 8999
+          startupProbe:
+            periodSeconds: 30
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8999
           volumeMounts:
             - name: nri-kubernetes-config
               mountPath: /etc/newrelic-infra/nri-kubernetes.yml

--- a/charts/newrelic-infrastructure/tests/probe_test.yaml
+++ b/charts/newrelic-infrastructure/tests/probe_test.yaml
@@ -1,0 +1,51 @@
+suite: test startup probe
+templates:
+  - templates/controlplane/daemonset.yaml
+  - templates/controlplane/scraper-configmap.yaml
+  - templates/controlplane/agent-configmap.yaml
+  - templates/kubelet/daemonset.yaml
+  - templates/kubelet/scraper-configmap.yaml
+  - templates/kubelet/agent-configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
+  - templates/ksm/deployment.yaml
+  - templates/ksm/scraper-configmap.yaml
+  - templates/ksm/agent-configmap.yaml
+  - templates/agent-configmap.yaml
+  - templates/secret.yaml
+tests:
+  - it: Startup probe is set if hostNetwork is false
+    set:
+      global:
+        hostNetwork: false
+      controlPlane:
+        hostNetwork: false
+      licenseKey: test
+      cluster: test
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].startupProbe
+        template: templates/ksm/deployment.yaml
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].startupProbe
+        template: templates/controlplane/daemonset.yaml
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].startupProbe
+        template: templates/kubelet/daemonset.yaml
+  - it: Startup probe is not if hostNetwork is true
+    set:
+      global:
+        hostNetwork: true
+      controlPlane:
+        hostNetwork: true
+      licenseKey: test
+      cluster: test
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe
+        template: templates/ksm/deployment.yaml
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe
+        template: templates/controlplane/daemonset.yaml
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe
+        template: templates/kubelet/daemonset.yaml

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -66,18 +66,6 @@ func main() {
 		logger.SetLevel(log.DebugLevel)
 	}
 
-	healthServer := health.New()
-
-	if c.HealthAddress != "" {
-		go func(address string) {
-			logger.Debugf("Starting health server")
-			err := healthServer.ListenAndServe(address)
-			if err != nil {
-				logger.Errorf("Error starting health server: %v", err)
-			}
-		}(c.HealthAddress)
-	}
-
 	if c.LogLevel != "" {
 		level, err := log.ParseLevel(c.LogLevel)
 		if err != nil {
@@ -85,6 +73,17 @@ func main() {
 		} else {
 			logger.SetLevel(level)
 		}
+	}
+
+	healthServer := health.New(health.WithLogger(logger))
+
+	if c.HealthAddress != "" {
+		go func(address string) {
+			err := healthServer.ListenAndServe(address)
+			if err != nil {
+				logger.Errorf("Error starting health server: %v", err)
+			}
+		}(c.HealthAddress)
 	}
 
 	integrationOptions := []integration.OptionFunc{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@ const (
 
 	DefaultNetworkRouteFile = "/proc/net/route"
 
+	DefaultHealthAddress = ":8999"
+
 	SinkTypeHTTP   = "http"
 	SinkTypeStdout = "stdout"
 )
@@ -46,6 +48,10 @@ type Config struct {
 		// HTTP stores the configuration for the HTTP sink.
 		HTTP HTTPSink `mapstructure:"http"`
 	} `mapstructure:"sink"`
+
+	// HealthAddress is the address in which the health server will listen for requests.
+	// If empty, the health server will not be started. Defaults to DefaultHealthAddress.
+	HealthAddress string `mapstructure:"healthAddress"`
 
 	// ControlPlane defines config options for the control plane scraper.
 	ControlPlane `mapstructure:"controlPlane"`
@@ -228,6 +234,7 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	v.SetDefault("kubelet.networkRouteFile", DefaultNetworkRouteFile)
 	v.SetDefault("nodeName", "node")
 	v.SetDefault("nodeIP", "node")
+	v.SetDefault("healthAddress", DefaultHealthAddress)
 
 	// Sane connection defaults
 	v.SetDefault("sink.type", SinkTypeHTTP)

--- a/src/health/health.go
+++ b/src/health/health.go
@@ -1,0 +1,71 @@
+// Package health implements a simple liveness probe.
+package health
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+const (
+	ReasonUninitialized = "Application has not been initialized yet"
+)
+
+// Server is an HTTP server that can be used as a liveness probe.
+type Server struct {
+	lock sync.RWMutex
+
+	healthy bool
+	reason  string
+}
+
+// New creates a new health.Server. A newly created Server is marked as unhealthy with ReasonUninitialized as the reason.
+func New() *Server {
+	return &Server{
+		healthy: false,
+		reason:  ReasonUninitialized,
+	}
+}
+
+// ListenAndServe sets the health.Server to listen in the supplied address, blocking until an error occurs.
+func (s *Server) ListenAndServe(address string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", s.health)
+
+	return http.ListenAndServe(address, mux)
+}
+
+// Healthy can be used to signal the Server the application is healthy. After Healthy has been called, the server will
+// start returning http.StatusOK until Unhealthy is called.
+func (s *Server) Healthy() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.healthy = true
+	s.reason = ""
+}
+
+// Unhealthy can be used to signal the Server the application is not healthy. If a reason is included, the server will
+// echo it in the HTTP response body.
+func (s *Server) Unhealthy(reason string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.healthy = false
+	s.reason = reason
+}
+
+// health is an http.HandlerFunc that returns http.StatusOK if server is flagged as healthy,
+// and http.StatusServiceUnavailable if it is not.
+func (s *Server) health(rw http.ResponseWriter, _ *http.Request) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if s.healthy {
+		rw.WriteHeader(http.StatusOK)
+		return
+	}
+
+	rw.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = io.WriteString(rw, s.reason)
+}


### PR DESCRIPTION
Right now, it is not possible for Kubernetes to know the state of the integration. While the integration currently exits whenever an error occurs, before entering the main loop it will be still waiting for some initialization to complete.

This PR adds a health server that can be used for the application to expose whether it is healthy or not. Currently, the main command of the integration sets the server to Healthy after the first successful scrape.