### PR TITLE
feat(readme): the yaml suffix is not needed

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.5.4
+version: 3.5.5
 appVersion: 3.2.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -1,6 +1,6 @@
 # newrelic-infrastructure
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
+![Version: 3.5.5](https://img.shields.io/badge/Version-3.5.5-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -496,8 +496,7 @@ integrations: {}
 # If you wish to monitor services running on Kubernetes you can provide integrations
 # configuration under `integrations`. You just need to create a new entry where
 # the key is the filename of the configuration file and the value is the content of
-# the integration configuration. The key must end in ".yaml" as this will be the
-# filename generated and the Infrastructure agent only looks for YAML files.
+# the integration configuration.
 # The data is the actual integration configuration as described in the spec here:
 # https://docs.newrelic.com/docs/integrations/integrations-sdk/file-specifications/integration-configuration-file-specifications-agent-v180
 # For example, if you wanted to monitor a Redis instance that has a label "app=sampleapp"


### PR DESCRIPTION
The readme was outdated and a bit confusing, now the "yaml" is added automatically:
```
  {{- if .Values.integrations -}}
  {{- range $k, $v := .Values.integrations -}}
  {{- $k | trimSuffix ".yaml" | trimSuffix ".yml" | nindent 2 -}}.yaml: |-
  {{- tpl ($v | toYaml) $ | nindent 4 -}}
  {{- end }}
  {{- end }}
```

Also the example key did not specify ".yaml" -> nri-redis-sampleapp