### PR TITLE
chart: set overide_host_root as an env var rather than a config entry

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.5.1
+version: 3.5.2
 appVersion: 3.2.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/templates/controlplane/_agent-config_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/controlplane/_agent-config_helper.tpl
@@ -3,7 +3,6 @@ Defaults for controlPlane's agent config
 */ -}}
 {{- define "nriKubernetes.controlPlane.agentConfig.defaults" -}}
 is_forward_only: true
-overide_host_root: ""  # Typo from here: https://github.com/newrelic/infrastructure-agent/blob/master/pkg/config/config.go#L267
 http_server_enabled: true
 http_server_port: 8001
 {{- end -}}

--- a/charts/newrelic-infrastructure/templates/ksm/_agent-config_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/ksm/_agent-config_helper.tpl
@@ -3,7 +3,6 @@ Defaults for ksm's agent config
 */ -}}
 {{- define "nriKubernetes.ksm.agentConfig.defaults" -}}
 is_forward_only: true
-overide_host_root: ""  # Typo from here: https://github.com/newrelic/infrastructure-agent/blob/master/pkg/config/config.go#L267
 http_server_enabled: true
 http_server_port: 8002
 {{- end -}}

--- a/charts/newrelic-infrastructure/templates/kubelet/_agent-config_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_agent-config_helper.tpl
@@ -8,7 +8,6 @@ features:
   docker_enabled: false
 {{- if not ( include "newrelic.common.privileged" . ) }}
 is_secure_forward_only: true
-overide_host_root: ""  # Typo from here: https://github.com/newrelic/infrastructure-agent/blob/master/pkg/config/config.go#L267
 {{- end }}
 {{- /*
 `enableProcessMetrics` is commented in the values and we want to configure it when it is set to something

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -125,6 +125,13 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
 
+            {{- if not (include "newrelic.common.privileged" .) }}
+            # Override NRIA_OVERRIDE_HOST_ROOT to empty if unprivileged. This must be done as an env var as the
+            # `k8s-events-forwarder` and `infrastructure-bundle` images ship this very same env var set to /host.
+            - name: "NRIA_OVERRIDE_HOST_ROOT"
+              value: ""
+            {{- end }}
+
             - name: "NRI_KUBERNETES_NODE_NAME"
               valueFrom:
                 fieldRef:

--- a/charts/newrelic-infrastructure/tests/configmap_cp_agent_test.yaml
+++ b/charts/newrelic-infrastructure/tests/configmap_cp_agent_test.yaml
@@ -20,7 +20,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
 
@@ -42,7 +41,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
 
@@ -68,7 +66,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
             test3: three
@@ -94,7 +91,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: override
 
@@ -118,7 +114,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: override
 
@@ -143,7 +138,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
 
   - it: eventQueueDepth is taken into account
     set:
@@ -167,7 +161,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8001
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
             test3: three

--- a/charts/newrelic-infrastructure/tests/configmap_ksm_agent_test.yaml
+++ b/charts/newrelic-infrastructure/tests/configmap_ksm_agent_test.yaml
@@ -20,7 +20,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
 
@@ -42,7 +41,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
 
@@ -68,7 +66,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
             test3: three
@@ -94,7 +91,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: override
 
@@ -118,7 +114,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: override
 
@@ -143,7 +138,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
 
   - it: eventQueueDepth is taken into account
     set:
@@ -167,7 +161,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8002
             is_forward_only: true
-            overide_host_root: ""
             test1: one
             test2: two
             test3: three

--- a/charts/newrelic-infrastructure/tests/configmap_kubelet_agent_test.yaml
+++ b/charts/newrelic-infrastructure/tests/configmap_kubelet_agent_test.yaml
@@ -190,7 +190,6 @@ tests:
             http_server_enabled: true
             http_server_port: 8003
             is_secure_forward_only: true
-            overide_host_root: ""
 
   - it: null enableProcessMetrics does not set enableProcessMetrics
     set:

--- a/charts/newrelic-infrastructure/tests/unprivileged_override_host_root_test.yaml
+++ b/charts/newrelic-infrastructure/tests/unprivileged_override_host_root_test.yaml
@@ -1,0 +1,33 @@
+suite: Test NRIA_OVERRIDE_HOST_ROOT
+templates:
+  - templates/kubelet/daemonset.yaml
+  - templates/kubelet/scraper-configmap.yaml
+  - templates/kubelet/agent-configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
+  - templates/agent-configmap.yaml
+  - templates/secret.yaml
+tests:
+  - it: NRIA_OVERRIDE_HOST_ROOT is not present in privileged mode
+    set:
+      licenseKey: test
+      cluster: test
+      privileged: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_OVERRIDE_HOST_ROOT"
+            value: ""
+        template: templates/kubelet/daemonset.yaml
+  - it: NRIA_OVERRIDE_HOST_ROOT is present in unprivileged mode
+    set:
+      licenseKey: test
+      cluster: test
+      privileged: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_OVERRIDE_HOST_ROOT"
+            value: ""
+        template: templates/kubelet/daemonset.yaml


### PR DESCRIPTION
This is needed as env vars take precedence over config values. We were setting this as a config value while unaware that the image we ship set these env vars in the Dockerfile.