### PR TITLE
go: upgrade to 1.18

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/nightlyAndMainImage.yml
+++ b/.github/workflows/nightlyAndMainImage.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/cache@v3
         with:
           path: |
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-go@v2
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Create image for chart testing
         if: steps.list-changed.outputs.changed == 'true'
         run: |
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
Go version in `go.mod` was updated in https://github.com/newrelic/nri-kubernetes/pull/403, but build pipelines did not reflect this change before this PR.

For traceability these changes were made with
```
find .github -type f  | xargs sed -i 's/1\.17/1.18/'
```
And then manually editing `e2e.yaml` to undo the wrong replacement on k8s 1.17.x.