### PR TITLE
Add k8s v1.23 & v1.24 new metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ validate:
 	@echo "[validate] Validating source code running golangci-lint & semgrep... "
 	go run -modfile tools/go.mod $(GOFLAGS) $(GOLANGCI_LINT) run --verbose
 	@[ -f .semgrep.yml ] && semgrep_config=".semgrep.yml" || semgrep_config="p/golang" ; \
-	docker run --rm -v "${PWD}:/src:ro" --workdir /src returntocorp/semgrep -c "$$semgrep_config"
+	docker run --rm -v "${PWD}:/src:ro" --workdir /src returntocorp/semgrep semgrep -c "$$semgrep_config"
 
 .PHONY: codespell
 codespell: CODESPELL_BIN := codespell

--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -105,7 +105,11 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 			versionAsserter := asserter
 			// apiserverStorageObjects replaces etcObjectCounts in k8s versions above 1.23
 			if testutil.IsBelow(version, testutil.Testdata123) {
-				versionAsserter = versionAsserter.Excluding(exclude.Metrics("apiserverStorageObjects"))
+				versionAsserter = versionAsserter.Excluding(
+					exclude.Metrics("apiserverStorageObjects", "nodeCollectorEvictionsDelta"))
+			} else if testutil.IsBelow(version, testutil.Testdata124) {
+				versionAsserter = versionAsserter.Excluding(
+					exclude.Metrics("nodeCollectorEvictionsDelta", "etcdObjectCounts"))
 			} else {
 				versionAsserter = versionAsserter.Excluding(exclude.Metrics("etcdObjectCounts"))
 			}

--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -101,15 +101,15 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 				t.Fatalf("running scraper: %v", err)
 			}
 
-			// Include specific specific exclusions that depend on version.
+			// Include specific exclusions that depend on version.
 			versionAsserter := asserter
+			if testutil.IsBelow(version, testutil.Testdata124) {
+				versionAsserter = versionAsserter.Excluding(exclude.Metrics("nodeCollectorEvictionsDelta"))
+			}
+
 			// apiserverStorageObjects replaces etcObjectCounts in k8s versions above 1.23
 			if testutil.IsBelow(version, testutil.Testdata123) {
-				versionAsserter = versionAsserter.Excluding(
-					exclude.Metrics("apiserverStorageObjects", "nodeCollectorEvictionsDelta"))
-			} else if testutil.IsBelow(version, testutil.Testdata124) {
-				versionAsserter = versionAsserter.Excluding(
-					exclude.Metrics("nodeCollectorEvictionsDelta", "etcdObjectCounts"))
+				versionAsserter = versionAsserter.Excluding(exclude.Metrics("apiserverStorageObjects"))
 			} else {
 				versionAsserter = versionAsserter.Excluding(exclude.Metrics("etcdObjectCounts"))
 			}

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -82,7 +82,7 @@ func TestScraper(t *testing.T) {
 			versionAsserter := asserter
 			if testutil.IsBelow(version, testutil.Testdata124) {
 				versionAsserter = versionAsserter.Excluding(
-					exclude.Metrics("nodeCollectorEvictionsDelta"))
+					exclude.Metrics("nodeCollectorEvictionsDelta", "containerOOMEventsDelta"))
 			}
 
 			// Call the asserter for the entities of this particular sub-test.

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -78,8 +78,15 @@ func TestScraper(t *testing.T) {
 				t.Fatalf("running scraper: %v", err)
 			}
 
+			// Include specific specific exclusions that depend on version.
+			versionAsserter := asserter
+			if testutil.IsBelow(version, testutil.Testdata124) {
+				versionAsserter = versionAsserter.Excluding(
+					exclude.Metrics("nodeCollectorEvictionsDelta"))
+			}
+
 			// Call the asserter for the entities of this particular sub-test.
-			asserter.On(i.Entities).Assert(t)
+			versionAsserter.On(i.Entities).Assert(t)
 		})
 	}
 }
@@ -97,7 +104,7 @@ func kubeletExclusions() []exclude.Func {
 	notRunningMetrics := []string{"memoryUsedBytes", "memoryWorkingSetBytes", "cpuUsedCores", "requestedMemoryUtilization",
 		"fsAvailableBytes", "fsCapacityBytes", "fsUsedBytes", "fsUsedPercent", "fsInodesFree", "fsInodes", "memoryUtilization",
 		"fsInodesUsed", "containerMemoryMappedFileBytes", "containerID", "containerImageID", "isReady", "podIP",
-		"cpuCoresUtilization", "requestedCpuCoresUtilization"}
+		"cpuCoresUtilization", "requestedCpuCoresUtilization", "containerOOMEventsDelta"}
 
 	// Utilization metrics will not be present if the corresponding limit/request is not present.
 	utilizationDependencies := map[string][]string{

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -206,9 +206,8 @@ var ControllerManagerSpecs = definition.SpecGroups{
 				ValueFunc: prometheus.FromValueWithOverriddenName(
 					"node_collector_evictions_total",
 					"nodeCollectorEvictionsDelta",
-					prometheus.IgnoreLabelsFilter("zone"),
 				),
-				Type: sdkMetric.DELTA,
+				Type: sdkMetric.PDELTA,
 			},
 		},
 	},
@@ -972,7 +971,7 @@ var KubeletSpecs = definition.SpecGroups{
 			{Name: "containerCpuCfsThrottledPeriodsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_periods_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerCpuCfsThrottledSecondsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_seconds_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerMemoryMappedFileBytes", ValueFunc: definition.FromRaw("container_memory_mapped_file"), Type: sdkMetric.GAUGE, Optional: true},
-			{Name: "containerOOMEventsDelta", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.DELTA, Optional: true},
+			{Name: "containerOOMEventsDelta", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.PDELTA, Optional: true},
 
 			// /pods endpoint
 			{Name: "containerName", ValueFunc: definition.FromRaw("containerName"), Type: sdkMetric.ATTRIBUTE},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -968,7 +968,7 @@ var KubeletSpecs = definition.SpecGroups{
 			{Name: "containerCpuCfsThrottledPeriodsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_periods_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerCpuCfsThrottledSecondsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_seconds_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerMemoryMappedFileBytes", ValueFunc: definition.FromRaw("container_memory_mapped_file"), Type: sdkMetric.GAUGE, Optional: true},
-			{Name: "containerOOMEventsTotal", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.DELTA},
+			{Name: "containerOOMEventsDelta", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.DELTA},
 
 			// /pods endpoint
 			{Name: "containerName", ValueFunc: definition.FromRaw("containerName"), Type: sdkMetric.ATTRIBUTE},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -201,6 +201,11 @@ var ControllerManagerSpecs = definition.SpecGroups{
 				ValueFunc: prometheus.FromValueWithOverriddenName("go_goroutines", "goGoroutines"),
 				Type:      sdkMetric.GAUGE,
 			},
+			{
+				Name:      "nodeCollectorEvictionsDelta",
+				ValueFunc: prometheus.FromValueWithOverriddenName("node_collector_evictions_total", "nodeCollectorEvictionsDelta"),
+				Type:      sdkMetric.DELTA,
+			},
 		},
 	},
 }
@@ -231,6 +236,9 @@ var ControllerManagerQueries = []prometheus.Query{
 	},
 	{
 		MetricName: "go_goroutines",
+	},
+	{
+		MetricName: "node_collector_evictions_total",
 	},
 }
 

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -900,6 +900,7 @@ var CadvisorQueries = []prometheus.Query{
 	{MetricName: "container_cpu_cfs_throttled_periods_total"},
 	{MetricName: "container_cpu_cfs_throttled_seconds_total"},
 	{MetricName: "container_memory_mapped_file"},
+	{MetricName: "container_oom_events_total"},
 }
 
 // KubeletSpecs are the metric specifications we want to collect from Kubelet.
@@ -959,6 +960,7 @@ var KubeletSpecs = definition.SpecGroups{
 			{Name: "containerCpuCfsThrottledPeriodsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_periods_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerCpuCfsThrottledSecondsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_seconds_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerMemoryMappedFileBytes", ValueFunc: definition.FromRaw("container_memory_mapped_file"), Type: sdkMetric.GAUGE, Optional: true},
+			{Name: "containerOOMEventsTotal", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.DELTA},
 
 			// /pods endpoint
 			{Name: "containerName", ValueFunc: definition.FromRaw("containerName"), Type: sdkMetric.ATTRIBUTE},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -49,6 +49,15 @@ var APIServerSpecs = definition.SpecGroups{
 				Type: sdkMetric.RATE,
 			},
 			{
+				Name: "apiserverCurrentInflightRequests",
+				ValueFunc: prometheus.FromValueWithOverriddenName(
+					"apiserver_current_inflight_requests",
+					"apiserverCurrentInflightRequests",
+					prometheus.IncludeOnlyLabelsFilter("request_kind"),
+				),
+				Type: sdkMetric.GAUGE,
+			},
+			{
 				Name: "restClientRequestsDelta",
 				ValueFunc: prometheus.FromValueWithOverriddenName(
 					"rest_client_requests_total",
@@ -120,6 +129,9 @@ var APIServerQueries = []prometheus.Query{
 	},
 	{
 		MetricName: "apiserver_storage_objects",
+	},
+	{
+		MetricName: "apiserver_current_inflight_requests",
 	},
 	{
 		MetricName: "process_resident_memory_bytes",

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -202,9 +202,13 @@ var ControllerManagerSpecs = definition.SpecGroups{
 				Type:      sdkMetric.GAUGE,
 			},
 			{
-				Name:      "nodeCollectorEvictionsDelta",
-				ValueFunc: prometheus.FromValueWithOverriddenName("node_collector_evictions_total", "nodeCollectorEvictionsDelta"),
-				Type:      sdkMetric.DELTA,
+				Name: "nodeCollectorEvictionsDelta",
+				ValueFunc: prometheus.FromValueWithOverriddenName(
+					"node_collector_evictions_total",
+					"nodeCollectorEvictionsDelta",
+					prometheus.IgnoreLabelsFilter("zone"),
+				),
+				Type: sdkMetric.DELTA,
 			},
 		},
 	},
@@ -968,7 +972,7 @@ var KubeletSpecs = definition.SpecGroups{
 			{Name: "containerCpuCfsThrottledPeriodsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_periods_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerCpuCfsThrottledSecondsTotal", ValueFunc: definition.FromRaw("container_cpu_cfs_throttled_seconds_total"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "containerMemoryMappedFileBytes", ValueFunc: definition.FromRaw("container_memory_mapped_file"), Type: sdkMetric.GAUGE, Optional: true},
-			{Name: "containerOOMEventsDelta", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.DELTA},
+			{Name: "containerOOMEventsDelta", ValueFunc: definition.FromRaw("container_oom_events_total"), Type: sdkMetric.DELTA, Optional: true},
 
 			// /pods endpoint
 			{Name: "containerName", ValueFunc: definition.FromRaw("containerName"), Type: sdkMetric.ATTRIBUTE},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -282,6 +282,11 @@ var SchedulerSpecs = definition.SpecGroups{
 				Type:      sdkMetric.DELTA,
 			},
 			{
+				Name:      "schedulerPendingPods",
+				ValueFunc: prometheus.FromValueWithOverriddenName("scheduler_pending_pods", "schedulerPendingPods"),
+				Type:      sdkMetric.GAUGE,
+			},
+			{
 				Name:      "schedulerPodPreemptionVictims",
 				ValueFunc: prometheus.FromValueWithOverriddenName("scheduler_pod_preemption_victims", "schedulerPodPreemptionVictims"),
 				Type:      sdkMetric.GAUGE,
@@ -327,6 +332,9 @@ var SchedulerQueries = []prometheus.Query{
 	},
 	{
 		MetricName: "scheduler_total_preemption_attempts",
+	},
+	{
+		MetricName: "scheduler_pending_pods",
 	},
 	{
 		MetricName: "scheduler_pod_preemption_victims",


### PR DESCRIPTION
Skipping e2e because could fail as it is not in the entity definitions yet.

Metrics added to the table of the metrics we have to add to the spec files: #455

