### PR TITLE
Update chart to the latest version of nri-kubernetes with namespace filtering

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,8 +8,8 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.5.5
-appVersion: 3.2.0
+version: 3.6.0
+appVersion: 3.3.0
 
 dependencies:
   - name: common-library

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -1,6 +1,6 @@
 # newrelic-infrastructure
 
-![Version: 3.5.5](https://img.shields.io/badge/Version-3.5.5-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 
@@ -114,6 +114,7 @@ integrations that you have configured.
 | common | object | See `values.yaml` | Config that applies to all instances of the solution: kubelet, ksm, control plane and sidecars. |
 | common.agentConfig | object | `{}` | Config for the Infrastructure agent. Will be used by the forwarder sidecars and the agent running integrations. See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
 | common.config.interval | duration | `15s` (See [Low data mode](README.md#low-data-mode)) | Intervals larger than 40s are not supported and will cause the NR UI to not behave properly. Any non-nil value will override the `lowDataMode` default. |
+| common.config.namespaceSelector | object | `{}` | Config for filtering ksm and kubelet metrics by namespace. |
 | containerSecurityContext | object | `{}` | Sets security context (at container level). Can be configured also with `global.containerSecurityContext` |
 | controlPlane | object | See `values.yaml` | Configuration for the control plane scraper. |
 | controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |

--- a/charts/newrelic-infrastructure/templates/clusterrole.yaml
+++ b/charts/newrelic-infrastructure/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
       - "endpoints"
       - "services"
       - "nodes"
+      - "namespaces"
     verbs: [ "get", "list", "watch" ]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -36,7 +36,7 @@ images:
   # @default -- See `values.yaml`
   integration:
     pullPolicy: IfNotPresent
-    tag: 3.2.1
+    tag: 3.3.0
     repository: newrelic/nri-kubernetes
     registry: ""
 
@@ -55,7 +55,7 @@ common:
     # matchLabels:
     #   newrelic.com/scrape: true
     # Otherwise you can build more complex filters and include or exclude certain namespaces by adding one or multiple
-    # expressions that are anded, for instance:
+    # expressions that are added, for instance:
     # matchExpressions:
     #   - {key: newrelic.com/scrape, operator: NotIn, values: [false]}
 


### PR DESCRIPTION
- Update chart to the latest version of nri-kubernetes with namespace filtering

- Update clusterrole to allow ns watch and list

Signed-off-by: Alvaro Cabanas <acabanas@newrelic.com>