### PR TITLE
fix(hostname): overriding fullhostname

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.6.0
+version: 3.6.1
 appVersion: 3.3.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -1,6 +1,6 @@
 # newrelic-infrastructure
 
-![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kubernetes monitoring solution
 

--- a/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
@@ -123,17 +123,8 @@ spec:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
 
-            - name: "NRIA_OVERRIDE_HOSTNAME_SHORT"
-              valueFrom:
-                fieldRef:
-                  apiVersion: "v1"
-                  fieldPath: "spec.nodeName"
-
-            - name: "NRIA_OVERRIDE_HOSTNAME"
-              valueFrom:
-                fieldRef:
-                  apiVersion: "v1"
-                  fieldPath: "spec.nodeName"
+            - name: "NRIA_DNS_HOSTNAME_RESOLUTION"
+              value: "false"
 
             - name: "K8S_NODE_NAME"
               valueFrom:

--- a/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
@@ -129,6 +129,12 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
 
+            - name: "NRIA_OVERRIDE_HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+
             - name: "K8S_NODE_NAME"
               valueFrom:
                 fieldRef:

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -117,6 +117,12 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
 
+            - name: "NRIA_OVERRIDE_HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+
             - name: "K8S_NODE_NAME"
               valueFrom:
                 fieldRef:

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -111,17 +111,8 @@ spec:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
 
-            - name: "NRIA_OVERRIDE_HOSTNAME_SHORT"
-              valueFrom:
-                fieldRef:
-                  apiVersion: "v1"
-                  fieldPath: "spec.nodeName"
-
-            - name: "NRIA_OVERRIDE_HOSTNAME"
-              valueFrom:
-                fieldRef:
-                  apiVersion: "v1"
-                  fieldPath: "spec.nodeName"
+            - name: "NRIA_DNS_HOSTNAME_RESOLUTION"
+              value: "false"
 
             - name: "K8S_NODE_NAME"
               valueFrom:

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -125,6 +125,12 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
 
+            - name: "NRIA_OVERRIDE_HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+
             {{- if not (include "newrelic.common.privileged" .) }}
             # Override NRIA_OVERRIDE_HOST_ROOT to empty if unprivileged. This must be done as an env var as the
             # `k8s-events-forwarder` and `infrastructure-bundle` images ship this very same env var set to /host.

--- a/charts/newrelic-infrastructure/tests/disable_dns_test.yaml
+++ b/charts/newrelic-infrastructure/tests/disable_dns_test.yaml
@@ -1,0 +1,29 @@
+suite: Test dns resolution is disabled for ksm and controlplane
+templates:
+  - templates/ksm/deployment.yaml
+  - templates/ksm/scraper-configmap.yaml
+  - templates/ksm/agent-configmap.yaml
+  - templates/controlplane/daemonset.yaml
+  - templates/controlplane/scraper-configmap.yaml
+  - templates/controlplane/agent-configmap.yaml
+  - templates/agent-configmap.yaml
+  - templates/secret.yaml
+tests:
+  - it: NRIA_DNS_HOSTNAME_RESOLUTION is set for the ksm and controlplane workloads
+    set:
+      licenseKey: test
+      cluster: test
+      privileged: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_DNS_HOSTNAME_RESOLUTION"
+            value: "false"
+        template: templates/controlplane/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_DNS_HOSTNAME_RESOLUTION"
+            value: "false"
+        template: templates/ksm/deployment.yaml

--- a/charts/newrelic-infrastructure/tests/hostname_override_test.yaml
+++ b/charts/newrelic-infrastructure/tests/hostname_override_test.yaml
@@ -1,0 +1,33 @@
+suite: Test override of hostname
+templates:
+  - templates/kubelet/daemonset.yaml
+  - templates/kubelet/scraper-configmap.yaml
+  - templates/kubelet/agent-configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
+  - templates/agent-configmap.yaml
+  - templates/secret.yaml
+tests:
+  - it: NRIA_OVERRIDE_HOSTNAME_SHORT and NRIA_OVERRIDE_HOSTNAME are set for the kubelet daemonset
+    set:
+      licenseKey: test
+      cluster: test
+      privileged: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_OVERRIDE_HOSTNAME_SHORT"
+            valueFrom:
+              fieldRef:
+                apiVersion: "v1"
+                fieldPath: "spec.nodeName"
+        template: templates/kubelet/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_OVERRIDE_HOSTNAME"
+            valueFrom:
+              fieldRef:
+                apiVersion: "v1"
+                fieldPath: "spec.nodeName"
+        template: templates/kubelet/daemonset.yaml


### PR DESCRIPTION
Fix https://github.com/newrelic/nri-kubernetes/issues/435

After some discussion, to avoid the fullHostname to be changing depending on the service bounded to the same nodeIP, the only path forward is to overwrite that with the node name.

 - In cloud environments the GUID is computed thanks to ID coming from the different vendors (es: ARN). 
 - On premise an unique identifier is not available and this change increases the chances of collisions (but [different parameters](https://github.com/newrelic/infrastructure-agent/blob/c19c3bad1913255fa1438775eb10b77ecb5f09c8/pkg/helpers/fingerprint/fingerprint.go#L61) are taken into account ). However, without the change the GUID could change depending on the fullHostname and therefore depending on the services running in the cluster. 

Notice that we need to specify both short and full hostname. Due to two separate issues.

