### PR TITLE
Parse matchLabels bool values as strings

### DIFF
--- a/cmd/nri-kubernetes/main_test.go
+++ b/cmd/nri-kubernetes/main_test.go
@@ -18,7 +18,7 @@ func TestSetupKubelet(t *testing.T) {
 		Verbose: false,
 		Kubelet: config.Kubelet{},
 		NamespaceSelector: &config.NamespaceSelector{
-			MatchLabels: map[string]string{
+			MatchLabels: map[string]interface{}{
 				"newrelic.com/scrape": "true",
 			},
 		},
@@ -40,7 +40,7 @@ func TestSetupKSM(t *testing.T) {
 		Verbose: false,
 		KSM:     config.KSM{},
 		NamespaceSelector: &config.NamespaceSelector{
-			MatchLabels: map[string]string{
+			MatchLabels: map[string]interface{}{
 				"newrelic.com/scrape": "true",
 			},
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -316,16 +316,18 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 	}
 
 	// Parse bool matchLabels values into strings.
-	matchLabels := make(map[string]interface{})
-	for k, v := range cfg.NamespaceSelector.MatchLabels {
-		str, err := ParseValueToString(v)
-		if err != nil {
-			return &cfg, err
+	if cfg.NamespaceSelector != nil && cfg.NamespaceSelector.MatchLabels != nil {
+		matchLabels := make(map[string]interface{})
+		for k, v := range cfg.NamespaceSelector.MatchLabels {
+			str, err := ParseValueToString(v)
+			if err != nil {
+				return &cfg, err
+			}
+			matchLabels[k] = str
 		}
-		matchLabels[k] = str
-	}
 
-	cfg.NamespaceSelector.MatchLabels = matchLabels
+		cfg.NamespaceSelector.MatchLabels = matchLabels
+	}
 
 	return &cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,7 +226,7 @@ type MTLS struct {
 // NamespaceSelector contains config options for filtering namespaces.
 type NamespaceSelector struct {
 	// MatchLabels is a list of labels to filter namespaces with.
-	MatchLabels map[string]string `mapstructure:"matchLabels"`
+	MatchLabels map[string]interface{} `mapstructure:"matchLabels"`
 	// MatchExpressions is a list of namespaces selector requirements.
 	MatchExpressions []Expression `mapstructure:"matchExpressions"`
 }
@@ -315,5 +315,35 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 		return nil, err
 	}
 
+	// Parse bool matchLabels values into strings.
+	matchLabels := make(map[string]interface{})
+	for k, v := range cfg.NamespaceSelector.MatchLabels {
+		str, err := ParseValueToString(v)
+		if err != nil {
+			return &cfg, err
+		}
+		matchLabels[k] = str
+	}
+
+	cfg.NamespaceSelector.MatchLabels = matchLabels
+
 	return &cfg, nil
+}
+
+func ParseValueToString(val interface{}) (string, error) {
+	var str string
+	switch v := val.(type) {
+	case string:
+		str = v
+	case bool:
+		str = strconv.FormatBool(v)
+	case int:
+		str = strconv.FormatInt(int64(v), 10)
+	case float32, float64:
+		str = fmt.Sprintf("%f", v)
+	default:
+		return "", fmt.Errorf("parsing matchLabels, invalid value type %T for val: %v", v, val)
+	}
+
+	return str, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,9 @@ import (
 
 const fakeDataDir = "testdata"
 const workingData = "config"
+
+// Added namespaceSelector config in a separate yaml, this way we can be sure there is no error in its absence.
+const workingDataWithNamespaceFilters = "config_with_namespace_filter"
 const unexpectedFields = "config_with_unexpected_fields"
 
 func TestLoadConfig(t *testing.T) {
@@ -37,17 +40,23 @@ func TestLoadConfig(t *testing.T) {
 	t.Run("succeeds_when_dot_character_in_key", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := config.LoadConfig(fakeDataDir, workingData)
+		c, err := config.LoadConfig(fakeDataDir, workingDataWithNamespaceFilters)
 		require.NoError(t, err)
 		require.Equal(t, "true", c.NamespaceSelector.MatchLabels["newrelic.com/scrape"])
 	})
 	t.Run("parses_bool_as_string", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := config.LoadConfig(fakeDataDir, workingData)
+		c, err := config.LoadConfig(fakeDataDir, workingDataWithNamespaceFilters)
 		require.NoError(t, err)
 		require.Equal(t, "true", c.NamespaceSelector.MatchLabels["another_label"])
 		require.Equal(t, "true", c.NamespaceSelector.MatchLabels["newrelic.com/scrape"])
+	})
+	t.Run("success_when_no_namespace_filters", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := config.LoadConfig(fakeDataDir, workingDataWithNamespaceFilters)
+		require.NoError(t, err)
 	})
 	t.Run("fail_due_to_unexpected_data", func(t *testing.T) {
 		t.Parallel()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,7 +39,15 @@ func TestLoadConfig(t *testing.T) {
 
 		c, err := config.LoadConfig(fakeDataDir, workingData)
 		require.NoError(t, err)
-		require.Equal(t, "1", c.NamespaceSelector.MatchLabels["newrelic.com/scrape"])
+		require.Equal(t, "true", c.NamespaceSelector.MatchLabels["newrelic.com/scrape"])
+	})
+	t.Run("parses_bool_as_string", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := config.LoadConfig(fakeDataDir, workingData)
+		require.NoError(t, err)
+		require.Equal(t, "true", c.NamespaceSelector.MatchLabels["another_label"])
+		require.Equal(t, "true", c.NamespaceSelector.MatchLabels["newrelic.com/scrape"])
 	})
 	t.Run("fail_due_to_unexpected_data", func(t *testing.T) {
 		t.Parallel()

--- a/internal/config/testdata/config.yml
+++ b/internal/config/testdata/config.yml
@@ -4,7 +4,8 @@ verbose: true
 
 namespaceSelector:
   matchLabels:
-    newrelic.com/scrape: true
+    newrelic.com/scrape: "true"
+    another_label: true
     
 sink:
   http:

--- a/internal/config/testdata/config.yml
+++ b/internal/config/testdata/config.yml
@@ -2,11 +2,6 @@ clusterName: dummy_cluster
 interval: 15
 verbose: true
 
-namespaceSelector:
-  matchLabels:
-    newrelic.com/scrape: "true"
-    another_label: true
-    
 sink:
   http:
     port: 8081

--- a/internal/config/testdata/config_with_namespace_filter.yml
+++ b/internal/config/testdata/config_with_namespace_filter.yml
@@ -1,0 +1,8 @@
+clusterName: dummy_cluster
+interval: 15
+verbose: true
+
+namespaceSelector:
+  matchLabels:
+    newrelic.com/scrape: "true"
+    another_label: true

--- a/internal/discovery/namespace_filter.go
+++ b/internal/discovery/namespace_filter.go
@@ -72,7 +72,7 @@ func (nf *NamespaceFilter) IsAllowed(namespace string) bool {
 
 // matchNamespaceByLabels filters a namespace using the selector from the MatchLabels config.
 func (nf *NamespaceFilter) matchNamespaceByLabels(namespace string) bool {
-	namespaceList, err := nf.lister.List(labels.SelectorFromSet(nf.c.MatchLabels))
+	namespaceList, err := nf.lister.List(labels.SelectorFromSet(parseToStringMap(nf.c.MatchLabels)))
 	if err != nil {
 		nf.logger.Errorf("listing namespaces with MatchLabels: %v", err)
 		return true
@@ -156,4 +156,18 @@ func containsNamespace(namespace string, namespaceList []*v1.Namespace) bool {
 	}
 
 	return false
+}
+
+func parseToStringMap(matchLabels map[string]interface{}) map[string]string {
+	strMap := make(map[string]string)
+
+	for k, v := range matchLabels {
+		str, err := config.ParseValueToString(v)
+		if err != nil {
+			continue
+		}
+		strMap[k] = str
+	}
+
+	return strMap
 }

--- a/internal/discovery/namespace_filter_test.go
+++ b/internal/discovery/namespace_filter_test.go
@@ -44,7 +44,7 @@ func TestNamespaceFilterer_IsAllowed(t *testing.T) {
 				"newrelic.com/scrape": "true",
 			},
 			namespaceSelector: config.NamespaceSelector{
-				MatchLabels: map[string]string{
+				MatchLabels: map[string]interface{}{
 					"newrelic.com/scrape": "true",
 				},
 			},
@@ -53,7 +53,7 @@ func TestNamespaceFilterer_IsAllowed(t *testing.T) {
 		"match_labels_excluded_namespaces_not_allowed": {
 			namespaceLabels: labels.Set{"newrelic.com/scrape": "false"},
 			namespaceSelector: config.NamespaceSelector{
-				MatchLabels: map[string]string{
+				MatchLabels: map[string]interface{}{
 					"newrelic.com/scrape": "true",
 				},
 			},
@@ -259,7 +259,7 @@ func TestNamespaceFilter_InformerCacheSync(t *testing.T) {
 	// Create the namespace filter.
 	ns := discovery.NewNamespaceFilter(
 		&config.NamespaceSelector{
-			MatchLabels: map[string]string{
+			MatchLabels: map[string]interface{}{
 				"test_label": "123",
 			},
 		},


### PR DESCRIPTION
Closes https://github.com/newrelic/newrelic-coreint/issues/342.

Viper even when unmarshalling to a `map[string]string` a bool values it magically parse it as `"1"`. This PR fixes this by parsing it as `"true"`.