### PR TITLE
fix(chart): removing doublerender to support old passthorugh notation

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.6.2
+version: 3.6.3
 appVersion: 3.3.1
 
 dependencies:

--- a/charts/newrelic-infrastructure/templates/kubelet/integrations-configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/integrations-configmap.yaml
@@ -31,7 +31,7 @@ data:
   {{- if .Values.integrations -}}
   {{- range $k, $v := .Values.integrations -}}
   {{- $k | trimSuffix ".yaml" | trimSuffix ".yml" | nindent 2 -}}.yaml: |-
-  {{- tpl ($v | toYaml) $ | nindent 4 -}}
+  {{- $v | toYaml | nindent 4 -}}
   {{- end }}
   {{- end }}
 

--- a/charts/newrelic-infrastructure/tests/configmap_integrations_test.yaml
+++ b/charts/newrelic-infrastructure/tests/configmap_integrations_test.yaml
@@ -200,3 +200,35 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+  - it: integrations options works with environment passthrough
+    set:
+      licenseKey: test
+      cluster: test
+      integrations:
+        nri-redis-sampleapp:
+          discovery:
+            command:
+              exec: /var/db/newrelic-infra/nri-discovery-kubernetes
+              match:
+                label.app: sampleapp
+          integrations:
+            - name: nri-redis
+              env:
+                PORT: "{{ SUPER_SECRET_VARIABLE }}"
+              labels:
+                env: test1
+    asserts:
+      - equal:
+          path: data.nri-redis-sampleapp\.yaml
+          value: |-
+            discovery:
+              command:
+                exec: /var/db/newrelic-infra/nri-discovery-kubernetes
+                match:
+                  label.app: sampleapp
+            integrations:
+            - env:
+                PORT: '{{ SUPER_SECRET_VARIABLE }}'
+              labels:
+                env: test1
+              name: nri-redis


### PR DESCRIPTION
I checked and that tpl was there since the very first implementation of v3, not really sure why we needed double templating (in that case we need to find a different solution). 

I am not aware of an use case based on that.

Fix https://github.com/newrelic/nri-kubernetes/issues/500