### PR TITLE
test: Add v1.23 and v1.24 e2e tests.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,16 +14,19 @@ jobs:
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
     runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 5 # len(k8sVersion)/2 is a good number to have here
+      max-parallel: 3 # len(k8sVersion)/2 is a good number to have here
       matrix:
         # Latest patch version can be found in https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
         # Some versions might not be available yet in https://storage.googleapis.com/kubernetes-release/release/v1.X.Y/bin/linux/amd64/kubelet
-        k8sVersion: [ "v1.22.3", "v1.21.4", "v1.20.10", "v1.19.14", "v1.18.20", "v1.17.17", "v1.16.15" ]
+        k8sVersion: [ "v1.24.1","v1.23.8","v1.22.11", "v1.21.14", "v1.16.15" ]
         cri: [ docker ]
+        exclude:
+          - k8sVersion: v1.24.1
+            cri: docker
         include:
-          - k8sVersion: v1.22.3
+          - k8sVersion: v1.24.1
             cri: containerd
-          - k8sVersion: v1.21.4
+          - k8sVersion: v1.23.8
             cri: containerd
     env:
       DOCKER_BUILDKIT: '1' # Setting DOCKER_BUILDKIT=1 ensures TARGETOS and TARGETARCH are populated
@@ -41,9 +44,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.6.0
         with:
-          minikube version: v1.23.2
+          minikube version: v1.26.0
           kubernetes version: ${{ matrix.k8sVersion }}
           driver: docker
           start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"
@@ -61,8 +64,22 @@ jobs:
           helm repo add newrelic https://helm-charts.newrelic.com
           helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
           helm repo update
+      - name: Select metrics exception file
+        id: exceptions-version
+        run: |
+          MINOR=$(echo "${{ matrix.k8sVersion }}"|sed -e 's_v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_\2_')
+
+          if [ "$MINOR" -le 22 ]; then
+            echo "::set-output name=exceptions::1_22"
+          elif [ "$MINOR" -eq 23 ]; then
+            echo "::set-output name=exceptions::1_23"
+          elif [ "$MINOR" -ge 24 ]; then 
+            echo "::set-output name=exceptions::1_24"
+          fi
       - name: Run e2e-test
         uses: newrelic/newrelic-integration-e2e-action@v1
+        env:
+          EXCEPTIONS_SOURCE_FILE: ${{ steps.exceptions-version.outputs.exceptions }}-exceptions.yml
         with:
           retry_seconds: 60
           retry_attempts: 5

--- a/e2e/1_22-exceptions.yml
+++ b/e2e/1_22-exceptions.yml
@@ -1,8 +1,11 @@
 # This metrics are not present from 1.22
 except_metrics:
 # Added from 1.23
-- k8s.apiserver.currentInflightRequests
-- k8s.scheduler.schedulerPendingPods
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating
+- k8s.scheduler.schedulerPendingPodsActive
+- k8s.scheduler.schedulerPendingPodsBackoff
+- k8s.scheduler.schedulerPendingPodsUnschedulable
 - k8s.apiserver.storageObjects_*
 # Added from 1.24
 - k8s.controllermanager.nodeCollectorEvictionsDelta

--- a/e2e/1_22-exceptions.yml
+++ b/e2e/1_22-exceptions.yml
@@ -1,0 +1,9 @@
+# This metrics are not present from 1.22
+except_metrics:
+# Added from 1.23
+- k8s.apiserver.currentInflightRequests
+- k8s.scheduler.schedulerPendingPods
+- k8s.apiserver.storageObjects_*
+# Added from 1.24
+- k8s.controllermanager.nodeCollectorEvictionsDelta
+- k8s.container.oomEventsDelta

--- a/e2e/1_23-exceptions.yml
+++ b/e2e/1_23-exceptions.yml
@@ -1,0 +1,12 @@
+# This metrics are not present on 1.23
+except_metrics:
+# removed from 1.23
+- k8s.apiserver.etcd.objectCount_*
+# Added from 1.24
+- k8s.controllermanager.nodeCollectorEvictionsDelta
+- k8s.container.oomEventsDelta
+
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.apiserver.currentInflightRequests
+- k8s.scheduler.schedulerPendingPods
+- k8s.apiserver.storageObjects_*

--- a/e2e/1_23-exceptions.yml
+++ b/e2e/1_23-exceptions.yml
@@ -7,6 +7,9 @@ except_metrics:
 - k8s.container.oomEventsDelta
 
 # This metrics are pending to be transformed as DM, once they are we can remove this exceptions
-- k8s.apiserver.currentInflightRequests
-- k8s.scheduler.schedulerPendingPods
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating
+- k8s.scheduler.schedulerPendingPodsActive
+- k8s.scheduler.schedulerPendingPodsBackoff
+- k8s.scheduler.schedulerPendingPodsUnschedulable
 - k8s.apiserver.storageObjects_*

--- a/e2e/1_24-exceptions.yml
+++ b/e2e/1_24-exceptions.yml
@@ -1,0 +1,10 @@
+# This metrics are not present on 1.24
+except_metrics:
+# removed from 1.23
+- k8s.apiserver.etcd.objectCount_*
+
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.controllermanager.nodeCollectorEvictionsDelta
+- k8s.apiserver.currentInflightRequests
+- k8s.scheduler.schedulerPendingPods
+- k8s.apiserver.storageObjects_*

--- a/e2e/1_24-exceptions.yml
+++ b/e2e/1_24-exceptions.yml
@@ -5,6 +5,9 @@ except_metrics:
 
 # This metrics are pending to be transformed as DM, once they are we can remove this exceptions
 - k8s.controllermanager.nodeCollectorEvictionsDelta
-- k8s.apiserver.currentInflightRequests
-- k8s.scheduler.schedulerPendingPods
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating
+- k8s.scheduler.schedulerPendingPodsActive
+- k8s.scheduler.schedulerPendingPodsBackoff
+- k8s.scheduler.schedulerPendingPodsUnschedulable
 - k8s.apiserver.storageObjects_*

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -37,7 +37,7 @@ go build -o  $GOPATH/bin/newrelic-integration-e2e ./cmd/...
 
 You can now run the e2e tests locally
 ```shell
-LICENSE_KEY=${LICENSE_KEY} newrelic-integration-e2e --commit_sha=test-string --retry_attempts=5 --retry_seconds=60 \
+LICENSE_KEY=${LICENSE_KEY} EXCEPTIONS_SOURCE_FILE=${EXCEPTION_FILE} newrelic-integration-e2e --commit_sha=test-string --retry_attempts=5 --retry_seconds=60 \
 	 --account_id=${ACCOUNT_ID} --api_key=${API_KEY} --license_key=${LICENSE_KEY} \
 	 --spec_path=./e2e/test-specs.yml --verbose_mode=true --agent_enabled="false"
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -42,4 +42,6 @@ LICENSE_KEY=${LICENSE_KEY} EXCEPTIONS_SOURCE_FILE=${EXCEPTION_FILE} newrelic-int
 	 --spec_path=./e2e/test-specs.yml --verbose_mode=true --agent_enabled="false"
 ```
 
+Since some metrics are removed and added depending on the k8s version, the `EXCEPTION_FILE` should point, depending on the k8s version you are testing on, to one of the `/e2e/*-exception.yml` files.
+
 You may check [e2e workflow](../.github/workflows/e2e.yaml) to have more details about how this is used in development workflow.

--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -1,4 +1,3 @@
-# https://source.datanerd.us/infrastructure/infra-integration-specs/blob/master/specs/kubernetes.yml
 specVersion: '1'
 owningTeam: fsi
 integrationName: kubernetes
@@ -30,6 +29,14 @@ entities:
           legacyEventType: K8sControllerManagerSample
           legacyNames:
             - leaderElectionMasterStatus
+      - name: k8s.controllermanager.nodeCollectorEvictionsDelta
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sControllerManagerSample
+          legacyNames:
+            - nodeCollectorEvictionsDelta
       - name: k8s.controllermanager.process.cpuSecondsDelta
         type: gauge
         defaultResolution: 15
@@ -270,6 +277,14 @@ entities:
           legacyEventType: K8sSchedulerSample
           legacyNames:
             - schedulerPodPreemptionVictims
+      - name: k8s.scheduler.schedulerPendingPods
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sSchedulerSample
+          legacyNames:
+            - schedulerPendingPods
       - name: k8s.scheduler.preemptionAttemptsDelta
         type: gauge
         defaultResolution: 15
@@ -334,6 +349,14 @@ entities:
           legacyEventType: K8sApiServerSample
           legacyNames:
             - goThreads
+      - name: k8s.apiserver.currentInflightRequests
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sApiServerSample
+          legacyNames:
+            - apiserverCurrentInflightRequests
       - name: k8s.apiserver.process.cpuSecondsDelta
         type: gauge
         defaultResolution: 15
@@ -390,6 +413,14 @@ entities:
           legacyEventType: K8sApiServerSample
           legacyNames:
             - etcdObjectCounts_*
+      - name: k8s.apiserver.storageObjects_*
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sApiServerSample
+          legacyNames:
+            - apiserverStorageObjects_*
     tags:
       - name: k8s.clusterName
         type: string
@@ -1552,6 +1583,14 @@ entities:
           legacyEventType: K8sContainerSample
           legacyNames:
             - restartCount
+      - name: k8s.container.restartCountDelta
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sContainerSample
+          legacyNames:
+            - restartCountDelta
       - name: k8s.container.cpuCoresUtilization
         type: gauge
         defaultResolution: 15
@@ -1608,6 +1647,14 @@ entities:
           legacyEventType: K8sContainerSample
           legacyNames:
             - containerMemoryMappedFileBytes
+      - name: k8s.container.oomEventsDelta
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sContainerSample
+          legacyNames:
+            - containerOOMEventsDelta
       - name: k8s.container.cpuCfsPeriodsDelta
         type: gauge
         defaultResolution: 15
@@ -4940,6 +4987,13 @@ entities:
             - status
           legacyEventTypes:
             - K8sNamespaceSample
+      - name: k8s.nrFiltered
+        type: string
+        migrationInformation:
+          legacyNames:
+            - nrFiltered
+          legacyEventTypes:
+            - K8sNamespaceSample
       - name: entity.guid
         type: string
         description: >-
@@ -5785,6 +5839,14 @@ entities:
           legacyEventType: K8sNodeSample
           legacyNames:
             - condition*
+      - name: k8s.node.cpuRequestedCores
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sNodeSample
+          legacyNames:
+            - cpuRequestedCores
       - name: k8s.node.cpuUsedCoreMilliseconds
         type: gauge
         defaultResolution: 15
@@ -5881,6 +5943,14 @@ entities:
           legacyEventType: K8sNodeSample
           legacyNames:
             - memoryRssBytes
+      - name: k8s.node.memoryRequestedBytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        migrationInformation:
+          legacyEventType: K8sNodeSample
+          legacyNames:
+            - memoryRequestedBytes
       - name: k8s.node.memoryUsedBytes
         type: gauge
         defaultResolution: 15
@@ -6014,6 +6084,13 @@ entities:
         migrationInformation:
           legacyNames:
             - nodeName
+          legacyEventTypes:
+            - K8sNodeSample
+      - name: k8s.kubeletVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - kubeletVersion
           legacyEventTypes:
             - K8sNodeSample
       - name: entity.guid

--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -1,5 +1,4 @@
 specVersion: '1'
-owningTeam: fsi
 integrationName: kubernetes
 humanReadableIntegrationName: Kubernetes
 entities:
@@ -277,14 +276,30 @@ entities:
           legacyEventType: K8sSchedulerSample
           legacyNames:
             - schedulerPodPreemptionVictims
-      - name: k8s.scheduler.schedulerPendingPods
+      - name: k8s.scheduler.schedulerPendingPodsActive
         type: gauge
         defaultResolution: 15
         unit: count
         migrationInformation:
           legacyEventType: K8sSchedulerSample
           legacyNames:
-            - schedulerPendingPods
+            - schedulerPendingPodsActive
+      - name: k8s.scheduler.schedulerPendingPodsBackoff
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sSchedulerSample
+          legacyNames:
+            - schedulerPendingPodsBackoff
+      - name: k8s.scheduler.schedulerPendingPodsUnschedulable
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sSchedulerSample
+          legacyNames:
+            - schedulerPendingPodsUnschedulable
       - name: k8s.scheduler.preemptionAttemptsDelta
         type: gauge
         defaultResolution: 15
@@ -349,14 +364,22 @@ entities:
           legacyEventType: K8sApiServerSample
           legacyNames:
             - goThreads
-      - name: k8s.apiserver.currentInflightRequests
+      - name: k8s.apiserver.currentInflightRequestsMutating
         type: gauge
         defaultResolution: 15
         unit: count
         migrationInformation:
           legacyEventType: K8sApiServerSample
           legacyNames:
-            - apiserverCurrentInflightRequests
+            - apiserverCurrentInflightRequestsMutating
+      - name: k8s.apiserver.currentInflightRequestsReadOnly
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sApiServerSample
+          legacyNames:
+            - apiserverCurrentInflightRequestsReadOnly
       - name: k8s.apiserver.process.cpuSecondsDelta
         type: gauge
         defaultResolution: 15

--- a/e2e/test-specs.yml
+++ b/e2e/test-specs.yml
@@ -21,6 +21,8 @@ scenarios:
       entities: []
       metrics:
         - source: "k8s.yml"
+          # EXCEPTIONS_SOURCE_FILE contains the path to the exceptions according to the k8s version.
+          exceptions_source: ${EXCEPTIONS_SOURCE_FILE}
           except_entities: []
           except_metrics:
             - k8s.node.allocatableHugepages*
@@ -40,6 +42,9 @@ scenarios:
             - k8s.pod.netRxBytesPerSecond
             - k8s.pod.netTxBytesPerSecond
 
+            # this metric does not appear when the scaler is not limited.
+            - k8s.hpa.isLimited
+
   - description: |
       This scenario will verify that metrics from a k8s Cluster are correctly collected without privileges.
     before:
@@ -57,6 +62,7 @@ scenarios:
       entities: []
       metrics:
         - source: "k8s.yml"
+          exceptions_source: ${EXCEPTIONS_SOURCE_FILE}
           except_entities:
             - K8sCluster # all metrics are related to controlPlane
           except_metrics:
@@ -69,3 +75,5 @@ scenarios:
             - k8s.pod.netErrorsPerSecond
             - k8s.pod.netRxBytesPerSecond
             - k8s.pod.netTxBytesPerSecond
+
+            - k8s.hpa.isLimited

--- a/e2e/test-specs.yml
+++ b/e2e/test-specs.yml
@@ -22,6 +22,7 @@ scenarios:
       metrics:
         - source: "k8s.yml"
           # EXCEPTIONS_SOURCE_FILE contains the path to the exceptions according to the k8s version.
+          # These exceptions files live in '/e2e' path and are selected on the GH e2e workflow.
           exceptions_source: ${EXCEPTIONS_SOURCE_FILE}
           except_entities: []
           except_metrics:


### PR DESCRIPTION
Closes #438 and Closes #448 but... since the metrics added on 1.23 and 1.24 are not yet correctly shimmed to DM I added to the exceptions. 

Exceptions metrics files has been added depending on the k8s version since some metrics were added and removed on different versions.

