### PR TITLE
Filter k8s metrics by label values

### DIFF
--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -109,7 +109,13 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 
 			// apiserverStorageObjects replaces etcObjectCounts in k8s versions above 1.23
 			if testutil.IsBelow(version, testutil.Testdata123) {
-				versionAsserter = versionAsserter.Excluding(exclude.Metrics("apiserverStorageObjects"))
+				versionAsserter = versionAsserter.Excluding(
+					exclude.Metrics(
+						"apiserverStorageObjects",
+						"apiserverCurrentInflightRequestsMutating",
+						"apiserverCurrentInflightRequestsReadOnly",
+					),
+				)
 			} else {
 				versionAsserter = versionAsserter.Excluding(exclude.Metrics("etcdObjectCounts"))
 			}

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -85,7 +85,7 @@ func TestScraper(t *testing.T) {
 				t.Fatalf("running scraper: %v", err)
 			}
 
-			// Include specific specific exclusions that depend on version.
+			// Include specific exclusions that depend on version.
 			versionAsserter := asserter
 			if testutil.IsBelow(version, testutil.Testdata124) {
 				versionAsserter = versionAsserter.Excluding(

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -50,19 +50,23 @@ var APIServerSpecs = definition.SpecGroups{
 			},
 			{
 				Name: "apiserverCurrentInflightRequestsMutating",
-				ValueFunc: prometheus.FromValueWithOverriddenName(
+				ValueFunc: prometheus.FromValueWithLabelsFilter(
 					"apiserver_current_inflight_requests",
 					"apiserverCurrentInflightRequestsMutating",
-					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"request_kind": "mutating"}),
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{
+						"request_kind": "mutating",
+					}),
 				),
 				Type: sdkMetric.GAUGE,
 			},
 			{
 				Name: "apiserverCurrentInflightRequestsReadOnly",
-				ValueFunc: prometheus.FromValueWithOverriddenName(
+				ValueFunc: prometheus.FromValueWithLabelsFilter(
 					"apiserver_current_inflight_requests",
 					"apiserverCurrentInflightRequestsReadOnly",
-					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"request_kind": "readOnly"}),
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{
+						"request_kind": "readOnly",
+					}),
 				),
 				Type: sdkMetric.GAUGE,
 			},
@@ -304,28 +308,34 @@ var SchedulerSpecs = definition.SpecGroups{
 			},
 			{
 				Name: "schedulerPendingPodsActive",
-				ValueFunc: prometheus.FromValueWithOverriddenName(
+				ValueFunc: prometheus.FromValueWithLabelsFilter(
 					"scheduler_pending_pods",
 					"schedulerPendingPodsActive",
-					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "active"}),
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{
+						"queue": "active",
+					}),
 				),
 				Type: sdkMetric.GAUGE,
 			},
 			{
 				Name: "schedulerPendingPodsBackoff",
-				ValueFunc: prometheus.FromValueWithOverriddenName(
+				ValueFunc: prometheus.FromValueWithLabelsFilter(
 					"scheduler_pending_pods",
 					"schedulerPendingPodsBackoff",
-					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "backoff"}),
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{
+						"queue": "backoff",
+					}),
 				),
 				Type: sdkMetric.GAUGE,
 			},
 			{
 				Name: "schedulerPendingPodsUnschedulable",
-				ValueFunc: prometheus.FromValueWithOverriddenName(
+				ValueFunc: prometheus.FromValueWithLabelsFilter(
 					"scheduler_pending_pods",
 					"schedulerPendingPodsUnschedulable",
-					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "unschedulable"}),
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{
+						"queue": "unschedulable",
+					}),
 				),
 				Type: sdkMetric.GAUGE,
 			},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -49,11 +49,20 @@ var APIServerSpecs = definition.SpecGroups{
 				Type: sdkMetric.RATE,
 			},
 			{
-				Name: "apiserverCurrentInflightRequests",
+				Name: "apiserverCurrentInflightRequestsMutating",
 				ValueFunc: prometheus.FromValueWithOverriddenName(
 					"apiserver_current_inflight_requests",
-					"apiserverCurrentInflightRequests",
-					prometheus.IncludeOnlyLabelsFilter("request_kind"),
+					"apiserverCurrentInflightRequestsMutating",
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"request_kind": "mutating"}),
+				),
+				Type: sdkMetric.GAUGE,
+			},
+			{
+				Name: "apiserverCurrentInflightRequestsReadOnly",
+				ValueFunc: prometheus.FromValueWithOverriddenName(
+					"apiserver_current_inflight_requests",
+					"apiserverCurrentInflightRequestsReadOnly",
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"request_kind": "readOnly"}),
 				),
 				Type: sdkMetric.GAUGE,
 			},
@@ -206,6 +215,7 @@ var ControllerManagerSpecs = definition.SpecGroups{
 				ValueFunc: prometheus.FromValueWithOverriddenName(
 					"node_collector_evictions_total",
 					"nodeCollectorEvictionsDelta",
+					prometheus.IgnoreLabelsFilter("zone"),
 				),
 				Type: sdkMetric.PDELTA,
 			},
@@ -293,9 +303,31 @@ var SchedulerSpecs = definition.SpecGroups{
 				Type:      sdkMetric.DELTA,
 			},
 			{
-				Name:      "schedulerPendingPods",
-				ValueFunc: prometheus.FromValueWithOverriddenName("scheduler_pending_pods", "schedulerPendingPods"),
-				Type:      sdkMetric.GAUGE,
+				Name: "schedulerPendingPodsActive",
+				ValueFunc: prometheus.FromValueWithOverriddenName(
+					"scheduler_pending_pods",
+					"schedulerPendingPodsActive",
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "active"}),
+				),
+				Type: sdkMetric.GAUGE,
+			},
+			{
+				Name: "schedulerPendingPodsBackoff",
+				ValueFunc: prometheus.FromValueWithOverriddenName(
+					"scheduler_pending_pods",
+					"schedulerPendingPodsBackoff",
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "backoff"}),
+				),
+				Type: sdkMetric.GAUGE,
+			},
+			{
+				Name: "schedulerPendingPodsUnschedulable",
+				ValueFunc: prometheus.FromValueWithOverriddenName(
+					"scheduler_pending_pods",
+					"schedulerPendingPodsUnschedulable",
+					prometheus.IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "unschedulable"}),
+				),
+				Type: sdkMetric.GAUGE,
 			},
 			{
 				Name:      "schedulerPodPreemptionVictims",

--- a/src/prometheus/definition.go
+++ b/src/prometheus/definition.go
@@ -314,6 +314,28 @@ func IncludeOnlyLabelsFilter(labelsToInclude ...string) func(Labels) Labels {
 	}
 }
 
+// IncludeOnlyWhenLabelMatchFilter returns a function that filters-out all but the
+// given label-value key pairs.
+func IncludeOnlyWhenLabelMatchFilter(labelsToInclude Labels) func(Labels) Labels {
+	return func(labels Labels) Labels {
+		filteredLabels := make(Labels)
+		for label, value := range labels {
+			include := false
+			for labelToInclude, valueToInclude := range labelsToInclude {
+				if label == labelToInclude && value == valueToInclude {
+					include = true
+					break
+				}
+			}
+
+			if include {
+				filteredLabels[label] = value
+			}
+		}
+		return filteredLabels
+	}
+}
+
 // attributeName generates the attribute name by suffixing the time-series
 // labels to the given metricName in order.
 func attributeName(metricName, nameOverride string, labels Labels, labelsFilter ...LabelsFilter) string {

--- a/src/prometheus/definition.go
+++ b/src/prometheus/definition.go
@@ -622,12 +622,7 @@ func hasMatchingLabels(metric Metric, labelsFilter ...LabelsFilter) bool {
 		labels = filter(labels)
 	}
 
-	// We skip the aggregation if there aren't matching labels.
-	if len(labels) == 0 {
-		return false
-	}
-
-	return true
+	return len(labels) != 0
 }
 
 // getMetricValue return the value of a given metric taking into account the aggregated and the metric value itself.

--- a/src/prometheus/definition_test.go
+++ b/src/prometheus/definition_test.go
@@ -6,12 +6,12 @@ import (
 	"math"
 	"testing"
 
-	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	model "github.com/prometheus/client_model/go"
+
+	"github.com/newrelic/infra-integrations-sdk/data/metric"
+	"github.com/newrelic/nri-kubernetes/v3/src/definition"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/newrelic/nri-kubernetes/v3/src/definition"
 )
 
 var mFamily = []MetricFamily{
@@ -872,6 +872,42 @@ func TestFetchFuncs_CorrectValue(t *testing.T) {
 			expectedFetchedValue: definition.FetchedValues{
 				"leader_election_master_status_name_kube-scheduler":    CounterValue(3),
 				"leader_election_master_status_name_kube-scheduler-02": CounterValue(7),
+			},
+		},
+		{
+			name: "FromValueWithOverriddenName correct aggregates and filters values",
+			rawGroups: definition.RawGroups{
+				"scheduler": {
+					"kube-scheduler-minikube": {
+						"scheduler_pending_pods": []Metric{
+							{
+								Labels: Labels{"queue": "active"},
+								Value:  CounterValue(1),
+							},
+							{
+								Labels: Labels{"queue": "backoff"},
+								Value:  CounterValue(2),
+							},
+							{
+								Labels: Labels{"queue": "unschedulable"},
+								Value:  CounterValue(3),
+							},
+							{
+								Labels: Labels{"queue": "active"},
+								Value:  CounterValue(4),
+							},
+						},
+					},
+				},
+			},
+			fetchFunc: FromValueWithOverriddenName(
+				"scheduler_pending_pods",
+				"",
+				IncludeOnlyWhenLabelMatchFilter(map[string]string{"queue": "active"}),
+			),
+			expectedFetchedValue: definition.FetchedValues{
+				"scheduler_pending_pods":              CounterValue(5),
+				"scheduler_pending_pods_queue_active": CounterValue(5),
 			},
 		},
 		{

--- a/src/prometheus/definition_test.go
+++ b/src/prometheus/definition_test.go
@@ -875,6 +875,27 @@ func TestFetchFuncs_CorrectValue(t *testing.T) {
 			},
 		},
 		{
+			name: "FromValueWithLabelsFilter skip aggregates value when no filter",
+			rawGroups: definition.RawGroups{
+				"scheduler": {
+					"kube-scheduler-minikube": {
+						"scheduler_pending_pods": []Metric{
+							{
+								Labels: Labels{"queue": "active"},
+								Value:  CounterValue(1),
+							},
+						},
+					},
+				},
+			},
+			fetchFunc: FromValueWithLabelsFilter(
+				"scheduler_pending_pods",
+				"",
+				IncludeOnlyWhenLabelMatchFilter(nil),
+			),
+			expectedFetchedValue: definition.FetchedValues{},
+		},
+		{
 			name: "FromValueWithLabelsFilter correct aggregates value with single filter",
 			rawGroups: definition.RawGroups{
 				"scheduler": {


### PR DESCRIPTION
This PR adds the capability to filter k8s metrics by label values.

This will avoid errors like this one  https://github.com/newrelic/nri-kubernetes/issues/397 we faced in the past.