### PR TITLE
fix(kubeletConnection): leverage token refresh

### DIFF
--- a/src/controlplane/client/authenticator/authenticator.go
+++ b/src/controlplane/client/authenticator/authenticator.go
@@ -80,7 +80,7 @@ func (a K8sClientAuthenticator) AuthenticatedTransport(endpoint config.Endpoint)
 	case strings.EqualFold(endpoint.Auth.Type, bearerAuth):
 		a.logger.Debugf("Using kubernetes token to authenticate request to %q", endpoint.URL)
 
-		transportConfig.BearerToken = a.InClusterConfig.BearerToken
+		transportConfig.BearerTokenFile = a.InClusterConfig.BearerTokenFile
 
 	case strings.EqualFold(endpoint.Auth.Type, mTLSAuth) && endpoint.Auth.MTLS != nil:
 		a.logger.Debugf("Using mTLS to authenticate request to %q", endpoint.URL)

--- a/src/controlplane/client/authenticator/authenticator_mtls_test.go
+++ b/src/controlplane/client/authenticator/authenticator_mtls_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ func Test_Authenticator_with_mTLS(t *testing.T) {
 				require.NoError(t, getErr)
 				bodyBytes, err := io.ReadAll(resp.Body)
 				require.NoError(t, err, "error reading response body")
-				assert.Equal(t, string(bodyBytes), testString, "expected body contents not found")
+				require.Equal(t, string(bodyBytes), testString, "expected body contents not found")
 			},
 		},
 		{
@@ -61,7 +60,7 @@ func Test_Authenticator_with_mTLS(t *testing.T) {
 				require.NoError(t, getErr)
 				bodyBytes, err := io.ReadAll(resp.Body)
 				require.NoError(t, err, "error reading response body")
-				assert.Equal(t, string(bodyBytes), testString, "expected body contents not found")
+				require.Equal(t, string(bodyBytes), testString, "expected body contents not found")
 			},
 		},
 		{

--- a/src/controlplane/client/authenticator/authenticator_test.go
+++ b/src/controlplane/client/authenticator/authenticator_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 
@@ -29,15 +28,15 @@ func Test_Authenticate_for_http_endpoint(t *testing.T) {
 	defer server.Close()
 
 	authenticator, err := authenticator.New(authenticator.Config{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rt, err := authenticator.AuthenticatedTransport(config.Endpoint{URL: server.URL})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c := &http.Client{Transport: rt}
 
 	_, err = c.Get(server.URL)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func Test_Authenticate_for_https_endpoint(t *testing.T) {
@@ -49,7 +48,7 @@ func Test_Authenticate_for_https_endpoint(t *testing.T) {
 	defer server.Close()
 
 	authenticator, err := authenticator.New(authenticator.Config{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	endpoint := config.Endpoint{
 		URL:                server.URL,
@@ -57,12 +56,12 @@ func Test_Authenticate_for_https_endpoint(t *testing.T) {
 	}
 
 	rt, err := authenticator.AuthenticatedTransport(endpoint)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c := &http.Client{Transport: rt}
 
 	_, err = c.Get(server.URL)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func Test_Authenticate_for_https_endpoint_with_bearer_token_auth(t *testing.T) {
@@ -74,7 +73,7 @@ func Test_Authenticate_for_https_endpoint_with_bearer_token_auth(t *testing.T) {
 		authenticator.Config{
 			InClusterConfig: &rest.Config{BearerTokenFile: bearerTokenFile},
 		})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	endpoint := config.Endpoint{
 		URL:                server.URL,
@@ -91,7 +90,7 @@ func Test_Authenticate_for_https_endpoint_with_bearer_token_auth(t *testing.T) {
 
 	resp, err := c.Get(server.URL)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func Test_Authenticator_fails_when(t *testing.T) {
@@ -165,7 +164,7 @@ func Test_Authenticator_fails_when(t *testing.T) {
 			t.Parallel()
 
 			authenticator, err := authenticator.New(authenticator.Config{})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = authenticator.AuthenticatedTransport(test.endpoint)
 			test.assert(t, err)

--- a/src/controlplane/client/authenticator/test_data/token
+++ b/src/controlplane/client/authenticator/test_data/token
@@ -1,0 +1,1 @@
+fake-token

--- a/src/kubelet/client/client_test.go
+++ b/src/kubelet/client/client_test.go
@@ -320,8 +320,7 @@ func getTestData(s *httptest.Server) (*fake.Clientset, *config.Config, *rest.Con
 	}
 
 	inClusterConfig := &rest.Config{
-		Host:        fmt.Sprintf("%s://%s", u.Scheme, u.Host),
-		BearerToken: "12345",
+		Host: fmt.Sprintf("%s://%s", u.Scheme, u.Host),
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: true,
 		},

--- a/src/kubelet/client/client_test.go
+++ b/src/kubelet/client/client_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -31,6 +32,7 @@ const (
 	kubeletMetric          = "/kubelet-metric"
 	kubeletMetricWithDelay = "/kubelet-metric-delay"
 	nodeName               = "test-node"
+	fakeTokenFile          = "./test_data/token"
 	retries                = 3
 )
 
@@ -250,8 +252,13 @@ func TestClientFailingProbingHTTPS(t *testing.T) {
 	t.Run("does_not_attach_bearer_token", func(t *testing.T) {
 		t.Parallel()
 
+		require.NotNil(t, requests)
+		data, err := ioutil.ReadFile(fakeTokenFile)
+
+		require.NoError(t, err)
+
 		for _, v := range requests {
-			assert.Equal(t, "Bearer 12345", v.Header["Authorization"][0])
+			assert.Equal(t, "Bearer "+string(data), v.Header["Authorization"][0])
 		}
 	})
 }
@@ -320,7 +327,8 @@ func getTestData(s *httptest.Server) (*fake.Clientset, *config.Config, *rest.Con
 	}
 
 	inClusterConfig := &rest.Config{
-		Host: fmt.Sprintf("%s://%s", u.Scheme, u.Host),
+		Host:            fmt.Sprintf("%s://%s", u.Scheme, u.Host),
+		BearerTokenFile: fakeTokenFile,
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: true,
 		},

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -49,7 +49,7 @@ func DefaultConnector(kc kubernetes.Interface, config *config.Config, inClusterC
 
 // Connect probes the kubelet connection locally and then through the apiServer proxy.
 // It tries to infer the scheme and the port found in node status DaemonEndpoints, if needed the user can set them up.
-// Locally it adds the bearer token to the request if protocol=https sing transport.NewBearerAuthRoundTripper,
+// Locally it adds the bearer token from the file to the request if protocol=https sing transport.NewBearerAuthWithRefreshRoundTripper,
 // on the other hand passing through api-proxy, authentication is managed by the kubernetes client itself.
 // Notice that we cannot use the as well rest.TransportFor to connect locally since the certificate sent by kubelet,
 // cannot be verified in the same way we do for the apiServer.
@@ -64,7 +64,7 @@ func (dp *defaultConnector) Connect() (*connParams, error) {
 	hostURL := net.JoinHostPort(dp.config.NodeIP, fmt.Sprint(kubeletPort))
 
 	dp.logger.Infof("Trying to connect to kubelet locally with scheme=%q hostURL=%q", kubeletScheme, hostURL)
-	trip, err := tripperWithBearerTokenAndRefresh(dp.inClusterConfig.BearerToken, dp.inClusterConfig.BearerTokenFile)
+	trip, err := tripperWithBearerTokenAndRefresh(dp.inClusterConfig.BearerTokenFile)
 	if err != nil {
 		return nil, fmt.Errorf("creating tripper connecting to kubelet through nodeIP: %w", err)
 	}
@@ -90,7 +90,7 @@ func (dp *defaultConnector) Connect() (*connParams, error) {
 	return conn, nil
 }
 
-func (dp *defaultConnector) checkLocalConnection(tripperWithBearerToken http.RoundTripper, scheme string, hostURL string) (*connParams, error) {
+func (dp *defaultConnector) checkLocalConnection(tripperWithBearerTokenRefreshing http.RoundTripper, scheme string, hostURL string) (*connParams, error) {
 	dp.logger.Debugf("connecting to kubelet directly with nodeIP")
 	var err error
 	var conn *connParams
@@ -101,14 +101,14 @@ func (dp *defaultConnector) checkLocalConnection(tripperWithBearerToken http.Rou
 			return conn, nil
 		}
 	case httpsScheme:
-		if conn, err = dp.checkConnectionHTTPS(hostURL, tripperWithBearerToken); err == nil {
+		if conn, err = dp.checkConnectionHTTPS(hostURL, tripperWithBearerTokenRefreshing); err == nil {
 			return conn, nil
 		}
 	default:
 		dp.logger.Infof("Checking both HTTP and HTTPS since the scheme was not detected automatically, " +
 			"you can set set kubelet.scheme to avoid this behaviour")
 
-		if conn, err = dp.checkConnectionHTTPS(hostURL, tripperWithBearerToken); err == nil {
+		if conn, err = dp.checkConnectionHTTPS(hostURL, tripperWithBearerTokenRefreshing); err == nil {
 			return conn, nil
 		}
 
@@ -200,10 +200,10 @@ func (dp *defaultConnector) checkConnectionHTTP(hostURL string) (*connParams, er
 	return &conn, nil
 }
 
-func (dp *defaultConnector) checkConnectionHTTPS(hostURL string, tripperBearer http.RoundTripper) (*connParams, error) {
+func (dp *defaultConnector) checkConnectionHTTPS(hostURL string, tripperBearerRefreshing http.RoundTripper) (*connParams, error) {
 	dp.logger.Debugf("testing kubelet connection over https to %s", hostURL)
 
-	conn := dp.defaultConnParamsHTTPS(hostURL, tripperBearer)
+	conn := dp.defaultConnParamsHTTPS(hostURL, tripperBearerRefreshing)
 	if err := checkConnection(conn); err != nil {
 		return nil, fmt.Errorf("checking connection via API proxy: %w", err)
 	}
@@ -232,7 +232,7 @@ func checkConnection(conn connParams) error {
 	return nil
 }
 
-func tripperWithBearerTokenAndRefresh(token string, tokenFile string) (http.RoundTripper, error) {
+func tripperWithBearerTokenAndRefresh(tokenFile string) (http.RoundTripper, error) {
 	// Here we're using the default http.Transport configuration, but with a modified TLS config.
 	// The DefaultTransport is casted to an http.RoundTripper interface, so we need to convert it back.
 	t := http.DefaultTransport.(*http.Transport).Clone()
@@ -240,12 +240,12 @@ func tripperWithBearerTokenAndRefresh(token string, tokenFile string) (http.Roun
 	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	// Use the default kubernetes Bearer token authentication RoundTripper
-	tripperWithBearer, err := transport.NewBearerAuthWithRefreshRoundTripper(token, tokenFile, t)
+	tripperWithBearerRefreshing, err := transport.NewBearerAuthWithRefreshRoundTripper("", tokenFile, t)
 	if err != nil {
 		return nil, fmt.Errorf("creating bearerAuthWithRefreshRoundTripper: %w", err)
 	}
 
-	return tripperWithBearer, nil
+	return tripperWithBearerRefreshing, nil
 }
 
 func (dp *defaultConnector) defaultConnParamsHTTP(hostURL string) connParams {

--- a/src/kubelet/client/test_data/token
+++ b/src/kubelet/client/test_data/token
@@ -1,0 +1,1 @@
+fake-token


### PR DESCRIPTION
Fix https://github.com/newrelic/nri-kubernetes/issues/511

Changing 
 - setting `NewBearerAuthWithRefreshRoundTripper` instead of `NewBearerAuthRoundTripper` to fix kubelet
and 
 - setting `transportConfig.BearerTokenFile` instead of  `transportConfig.BearerToken` to fix controlPlane
 - using `require` to avoid null pointer exception if creation of some resources fails and also if they are the only condition tested in a test-case (basically to remove an import)