### PR TITLE
fix: remove fixed serviceAccount.create of values

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.7.3
+version: 3.7.4
 appVersion: 3.4.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/tests/serviceaccount_create_test.yaml
+++ b/charts/newrelic-infrastructure/tests/serviceaccount_create_test.yaml
@@ -1,0 +1,75 @@
+suite: test service accounts creation
+templates:
+  - templates/serviceaccount.yaml
+  - templates/controlplane/serviceaccount.yaml
+release:
+  licenseKey: test
+  cluster: test
+tests:
+  - it: default values template a service account
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: no global values template a service account
+    set:
+      global: null
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: create (globally) a service account
+    set:
+      global:
+        serviceAccount:
+          create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: create (locally) a service account
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: disable (globally) a service account
+    set:
+      global:
+        serviceAccount:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: disable (locally) a service account
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Allow to override the global disable of a service account
+    set:
+      global:
+        serviceAccount:
+          create: true
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Allow to override the global creation of a service account
+    set:
+      global:
+        serviceAccount:
+          create: false
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -449,7 +449,7 @@ customAttributes: {}
 # @default -- See `values.yaml`
 serviceAccount:
   # -- Whether the chart should automatically create the ServiceAccount objects required to run.
-  create: true
+  create:
   annotations: {}
   # If not set and create is true, a name is generated using the fullname template
   name: ""


### PR DESCRIPTION
Having the `create: true` on the default values of the chart was preventing the global values to overwrite this config ([issue](https://github.com/newrelic/helm-charts/issues/875))

This PR removes the default values so the `global.serviceAccount` are honored.