### PR TITLE
[helm chart] Patch job should also honor the global service account flag

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.7.2
+version: 3.7.3
 appVersion: 3.4.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.7.1
+version: 3.7.2
 appVersion: 3.4.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/templates/_helpers_compatibility.tpl
+++ b/charts/newrelic-infrastructure/templates/_helpers_compatibility.tpl
@@ -64,8 +64,8 @@ Returns legacy annotations if available
 Returns agent configmap merged with legacy config and legacy eventQueueDepth config
 */}}
 {{- define "newrelic.compatibility.agentConfig" -}}
-{{- $oldConfig := .Values.config | default dict -}}
-{{- $newConfig := .Values.common.agentConfig  -}}
+{{- $oldConfig := deepCopy (.Values.config | default dict) -}}
+{{- $newConfig := deepCopy .Values.common.agentConfig -}}
 {{- $eventQueueDepth := dict -}}
 
 {{- if .Values.eventQueueDepth -}}

--- a/charts/newrelic-infrastructure/templates/controlplane/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/controlplane/_naming.tpl
@@ -6,3 +6,11 @@
 {{- define "nriKubernetes.controlplane.fullname.agent" -}}
 {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent-controlplane") -}}
 {{- end -}}
+
+{{- define "nriKubernetes.controlplane.fullname.serviceAccount" -}}
+{{- if include "newrelic.common.serviceAccount.create" . -}}
+  {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "controlplane") -}}
+{{- else -}}
+  {{- include "newrelic.common.serviceAccount.name" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/controlplane/clusterrolebinding.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/clusterrolebinding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ include "nriKubernetes.controlplane.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "newrelic.common.serviceAccount.name" . }}-controlplane
+    name: {{ include "nriKubernetes.controlplane.fullname.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
       securityContext:
         {{- . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}-controlplane
+      serviceAccountName: {{ include "nriKubernetes.controlplane.fullname.serviceAccount" . }}
 
       {{- if .Values.controlPlane.initContainers }}
       initContainers: {{- tpl (.Values.controlPlane.initContainers | toYaml) . | nindent 8 }}

--- a/charts/newrelic-infrastructure/templates/controlplane/rolebinding.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/rolebinding.yaml
@@ -15,7 +15,7 @@ roleRef:
   name: {{ include "nriKubernetes.naming.secrets" $ }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "newrelic.common.serviceAccount.name" $ }}-controlplane
+  name: {{ include "nriKubernetes.controlplane.fullname.serviceAccount" $ }}
   namespace: {{ $.Release.Namespace }}
 {{- end -}}
 {{- end }}

--- a/charts/newrelic-infrastructure/templates/controlplane/serviceaccount.yaml
+++ b/charts/newrelic-infrastructure/templates/controlplane/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
   {{- end }}
   labels:
     {{- include "newrelic.common.labels" . | nindent 4 }}
-  name: {{ include "newrelic.common.serviceAccount.name" . }}-controlplane
+  name: {{ include "nriKubernetes.controlplane.fullname.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/newrelic-infrastructure/tests/controlplane_rbac_test.yaml
+++ b/charts/newrelic-infrastructure/tests/controlplane_rbac_test.yaml
@@ -1,0 +1,41 @@
+suite: test RBAC creation
+templates:
+  - templates/controlplane/rolebinding.yaml
+  - templates/controlplane/clusterrolebinding.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+      # The line below is to create one rolebinding to test it.
+      controlPlane.config.apiServer.staticEndpoint.auth.mtls.secretNamespace: test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: my-release-nrk8s-controlplane
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+      # The line below is to create one rolebinding to test it.
+      controlPlane.config.apiServer.staticEndpoint.auth.mtls.secretNamespace: test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      # The line below is to create one rolebinding to test it.
+      controlPlane.config.apiServer.staticEndpoint.auth.mtls.secretNamespace: test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: default

--- a/charts/newrelic-infrastructure/tests/controlplane_serviceAccount_test.yaml
+++ b/charts/newrelic-infrastructure/tests/controlplane_serviceAccount_test.yaml
@@ -1,0 +1,46 @@
+suite: test control plane' serviceAccount
+templates:
+  - templates/controlplane/daemonset.yaml
+  - templates/controlplane/scraper-configmap.yaml
+  - templates/controlplane/agent-configmap.yaml
+  - templates/secret.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      licenseKey: test
+      cluster: test
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-release-nrk8s-controlplane
+        template: templates/controlplane/daemonset.yaml
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      licenseKey: test
+      cluster: test
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: sa-test
+        template: templates/controlplane/daemonset.yaml
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      licenseKey: test
+      cluster: test
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+        template: templates/controlplane/daemonset.yaml

--- a/charts/newrelic-infrastructure/tests/interval_override_test.yaml
+++ b/charts/newrelic-infrastructure/tests/interval_override_test.yaml
@@ -1,4 +1,4 @@
-suite: test interval
+suite: test interval override
 templates:
   - templates/controlplane/scraper-configmap.yaml
   - templates/ksm/scraper-configmap.yaml


### PR DESCRIPTION
There is an issue open by GTS saying that not all the charts honor the flag `.global.serviceAccount.create` and `.global.serviceAccount.name`: newrelic/helm-charts#875

There is not also the issue that they are not honored by the deployments but also by the jobs that create and patch webhook certificates.

Fixes #514