### PR TITLE
[helm chart] `deepCopy` values when we are going to do a `mergeOverwrite`

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/master/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.7.2
+version: 3.7.3
 appVersion: 3.4.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/templates/_helpers_compatibility.tpl
+++ b/charts/newrelic-infrastructure/templates/_helpers_compatibility.tpl
@@ -64,8 +64,8 @@ Returns legacy annotations if available
 Returns agent configmap merged with legacy config and legacy eventQueueDepth config
 */}}
 {{- define "newrelic.compatibility.agentConfig" -}}
-{{- $oldConfig := .Values.config | default dict -}}
-{{- $newConfig := .Values.common.agentConfig  -}}
+{{- $oldConfig := deepCopy (.Values.config | default dict) -}}
+{{- $newConfig := deepCopy .Values.common.agentConfig -}}
 {{- $eventQueueDepth := dict -}}
 
 {{- if .Values.eventQueueDepth -}}


### PR DESCRIPTION
This is the only chart remaining to fix the issue newrelic/helm-charts#858

Go to the issues linked for having all the context.

TL;DR: `mergeOverwrite` does not only return the resulting dict but also modifies the first parameter so we have to `deepCopy`  it to not change values for the rest of the helpers/templates.

Fixes newrelic/helm-charts#858