### PR TITLE
Allow kind to be set for kubelet

### DIFF
--- a/charts/newrelic-infrastructure/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.kubelet.enabled }}
 {{- if not .Values.forceUnsupportedInterval }}
 {{- $max := 40 }}
 {{- $min := 10 }}
@@ -9,6 +10,7 @@
 {{- end }}
 {{- if lt ( .Values.common.config.interval | trimSuffix "s" | int64 ) $min }}
 {{ fail (printf "Intervals smaller than %ds are not supported" $min) }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/newrelic-infrastructure/templates/deployment/_affinity_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/deployment/_affinity_helper.tpl
@@ -1,0 +1,33 @@
+{{- /*
+Patch to add affinity in case we are running in fargate mode
+*/ -}}
+{{- define "nriKubernetes.deployment.affinity.fargateDefaults" -}}
+nodeAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: eks.amazonaws.com/compute-type
+            operator: NotIn
+            values:
+              - fargate
+{{- end -}}
+
+
+
+{{- /*
+As this chart deploys what it should be three charts to maintain the transition to v3 as smooth as possible.
+This means that this chart has 3 affinity so a helper should be done per scraper.
+*/ -}}
+{{- define "nriKubernetes.deployment.affinity" -}}
+
+{{- if or .Values.deployment.affinity .Values.nodeAffinity  -}}
+    {{- $legacyNodeAffinity := fromYaml ( include "newrelic.compatibility.nodeAffinity" . ) | default dict -}}
+    {{- $valuesAffinity := .Values.deployment.affinity | default dict -}}
+    {{- $affinity := mustMergeOverwrite $legacyNodeAffinity $valuesAffinity -}}
+    {{- toYaml $affinity -}}
+{{- else if include "newrelic.common.affinity" . -}}
+    {{- include "newrelic.common.affinity" . -}}
+{{- else if include "newrelic.fargate" . -}}
+    {{- include "nriKubernetes.deployment.affinity.fargateDefaults" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/deployment/_agent-config_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/deployment/_agent-config_helper.tpl
@@ -1,0 +1,31 @@
+{{- /*
+Defaults for deployment's agent config
+*/ -}}
+{{- define "nriKubernetes.deployment.agentConfig.defaults" -}}
+http_server_enabled: true
+http_server_port: 8003
+features:
+  docker_enabled: false
+{{- if not ( include "newrelic.common.privileged" . ) }}
+is_secure_forward_only: true
+{{- end }}
+{{- /*
+`enableProcessMetrics` is commented in the values and we want to configure it when it is set to something
+either `true` or `false`. So we test if the variable is a boolean and in that case simply use it.
+*/}}
+{{- if (get .Values "enableProcessMetrics" | kindIs "bool") }}
+enable_process_metrics: {{ .Values.enableProcessMetrics }}
+{{- end }}
+{{- end -}}
+
+
+
+{{- define "nriKubernetes.deployment.agentConfig" -}}
+{{- $agentDefaults := fromYaml ( include "newrelic.common.agentConfig.defaults" . ) -}}
+{{- $deployment := fromYaml ( include "nriKubernetes.deployment.agentConfig.defaults" . ) -}}
+{{- $agentConfig := fromYaml ( include "newrelic.compatibility.agentConfig" . ) -}}
+{{- $deploymentAgentConfig := .Values.deployment.agentConfig -}}
+{{- $customAttributes := dict "custom_attributes" (dict "clusterName" (include "newrelic.common.cluster" . )) -}}
+
+{{- mustMergeOverwrite $agentDefaults $deployment $agentConfig $deploymentAgentConfig $customAttributes | toYaml -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/deployment/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/deployment/_naming.tpl
@@ -1,0 +1,12 @@
+{{- /* Naming helpers*/ -}}
+{{- define "nriKubernetes.deployment.fullname" -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "deployment") -}}
+{{- end -}}
+
+{{- define "nriKubernetes.deployment.fullname.agent" -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent-deployment") -}}
+{{- end -}}
+
+{{- define "nriKubernetes.deployment.fullname.integrations" -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "deployment-integrations-cfg") -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/deployment/_security_context_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/deployment/_security_context_helper.tpl
@@ -1,0 +1,32 @@
+{{- /*This defines the defaults that the privileged mode has for the agent's securityContext */ -}}
+{{- define "nriKubernetes.deployment.securityContext.privileged" -}}
+runAsUser: 0
+runAsGroup: 0
+allowPrivilegeEscalation: true
+privileged: true
+readOnlyRootFilesystem: true
+{{- end -}}
+
+
+
+{{- /* This is the container security context for the agent */ -}}
+{{- define "nriKubernetes.deployment.securityContext.agentContainer" -}}
+{{- $defaults := dict -}}
+{{- if include "newrelic.common.privileged" . -}}
+{{- $defaults = fromYaml ( include "nriKubernetes.deployment.securityContext.privileged" . ) -}}
+{{- else -}}
+{{- $defaults = fromYaml ( include "nriKubernetes.securityContext.containerDefaults" . ) -}}
+{{- end -}}
+
+{{- $compatibilityLayer := include "newrelic.compatibility.securityContext" . | fromYaml -}}
+{{- $commonLibrary := include "newrelic.common.securityContext.container" . | fromYaml -}}
+
+{{- $finalSecurityContext := dict -}}
+{{- if $commonLibrary -}}
+    {{- $finalSecurityContext = mustMergeOverwrite $commonLibrary $compatibilityLayer -}}
+{{- else -}}
+    {{- $finalSecurityContext = mustMergeOverwrite $defaults $compatibilityLayer -}}
+{{- end -}}
+
+{{- toYaml $finalSecurityContext -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/deployment/_tolerations_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/deployment/_tolerations_helper.tpl
@@ -1,0 +1,11 @@
+{{- /*
+As this chart deploys what it should be three charts to maintain the transition to v3 as smooth as possible.
+This means that this chart has 3 tolerations so a helper should be done per scraper.
+*/ -}}
+{{- define "nriKubernetes.deployment.tolerations" -}}
+{{- if .Values.deployment.tolerations -}}
+    {{- toYaml .Values.deployment.tolerations -}}
+{{- else if include "newrelic.common.tolerations" . -}}
+    {{- include "newrelic.common.tolerations" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/deployment/agent-configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/deployment/agent-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.deployment.enabled -}}
+{{- if .Values.customAttributes | kindIs "string" }}
+{{- fail ( include "newrelic.compatibility.message.customAttributes" . ) -}}
+{{- else -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "nriKubernetes.deployment.fullname.agent" . }}
+data:
+  newrelic-infra.yml: |-
+    # This is the configuration file for the infrastructure agent. See:
+    # https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/
+    {{- include "nriKubernetes.deployment.agentConfig" . | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/deployment/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/deployment/deployment.yaml
@@ -1,0 +1,208 @@
+{{- if (.Values.deployment.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nriKubernetes.labels" . | nindent 4 }}
+  name: {{ include "nriKubernetes.deployment.fullname" . }}
+  {{- $legacyAnnotation:= fromYaml (include "newrelic.compatibility.annotations" .) -}}
+  {{- with  include "newrelic.compatibility.valueWithFallback" (dict "legacy" $legacyAnnotation "supported" .Values.deployment.annotations )}}
+  annotations: {{ . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "newrelic.common.labels.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: deployment
+  template:
+    metadata:
+      annotations:
+        checksum/agent-config: {{ include (print $.Template.BasePath "/deployment/agent-configmap.yaml") . | sha256sum }}
+        {{- if include "newrelic.common.license.secret" . }}{{- /* If the is secret to template */}}
+        checksum/license-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        checksum/integrations_config: {{ include (print $.Template.BasePath "/deployment/integrations-configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "nriKubernetes.labels.podLabels" . | nindent 8 }}
+        app.kubernetes.io/component: deployment
+    spec:
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.images.pullSecrets) "context" .) }}
+      imagePullSecrets:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with include "newrelic.common.dnsConfig" . }}
+      dnsConfig:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with include "newrelic.common.priorityClassName" . }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with include "newrelic.common.securityContext.pod" . }}
+      securityContext:
+        {{- . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
+      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
+      {{- if include "nriKubernetes.controlPlane.hostNetwork" . }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+
+      {{- if .Values.deployment.initContainers }}
+      initContainers: {{- tpl (.Values.deployment.initContainers | toYaml) . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.images.agent "context" .) }}
+          args: [ "newrelic-infra" ]
+          imagePullPolicy: {{ .Values.images.agent.pullPolicy }}
+          {{- with include "nriKubernetes.deployment.securityContext.agentContainer" . | fromYaml }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ get (fromYaml (include "nriKubernetes.deployment.agentConfig" .)) "http_server_port" }}
+          env:
+            - name: NRIA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.license.secretName" . }}
+                  key: {{ include "newrelic.common.license.secretKeyName" . }}
+
+            - name: "NRIA_OVERRIDE_HOSTNAME_SHORT"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+
+            - name: "NRIA_OVERRIDE_HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+
+            {{- if not (include "newrelic.common.privileged" .) }}
+            # Override NRIA_OVERRIDE_HOST_ROOT to empty if unprivileged. This must be done as an env var as the
+            # `k8s-events-forwarder` and `infrastructure-bundle` images ship this very same env var set to /host.
+            - name: "NRIA_OVERRIDE_HOST_ROOT"
+              value: ""
+            {{- end }}
+
+            - name: "NRI_KUBERNETES_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+
+            {{- if .Values.useNodeNameAsDisplayName }}
+            - name: "NRIA_DISPLAY_NAME"
+            {{- if .Values.prefixDisplayNameWithCluster }}
+              value: "{{ include "newrelic.common.cluster" . }}:$(NRI_KUBERNETES_NODE_NAME)"
+            {{- else }}
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+            {{- end }}
+            {{- end }}
+
+            {{- /* Needed to populate clustername in integration metrics */}}
+            - name: "CLUSTER_NAME"
+              value: {{ include "newrelic.common.cluster" . }}
+            - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+              value: "CLUSTER_NAME"
+
+            {{- /* Needed for autodiscovery since hostNetwork=false */}}
+            - name: "NRIA_HOST"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "status.hostIP"
+
+            {{- with .Values.deployment.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.deployment.extraEnvFrom }}
+          envFrom: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/newrelic-infra.yml
+              subPath: newrelic-infra.yml
+            - name: nri-integrations-cfg-volume
+              mountPath: /etc/newrelic-infra/integrations.d/
+            {{- if include "newrelic.common.privileged" . }}
+            - name: dev
+              mountPath: /dev
+            - name: host-docker-socket
+              mountPath: /var/run/docker.sock
+            - name: log
+              mountPath: /var/log
+            - name: host-volume
+              mountPath: /host
+              readOnly: true
+            {{- end }}
+            - mountPath: /var/db/newrelic-infra/data
+              name: agent-tmpfs-data
+            - mountPath: /var/db/newrelic-infra/user_data
+              name: agent-tmpfs-user-data
+            - mountPath: /tmp
+              name: agent-tmpfs-tmp
+            {{- with .Values.deployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.deployment.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- if include "newrelic.common.privileged" . }}
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: host-docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+        - name: log
+          hostPath:
+            path: /var/log
+        - name: host-volume
+          hostPath:
+            path: /
+        {{- end }}
+        - name: agent-tmpfs-data
+          emptyDir: {}
+        - name: agent-tmpfs-user-data
+          emptyDir: {}
+        - name: agent-tmpfs-tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ include "nriKubernetes.deployment.fullname.agent" . }}
+            items:
+              - key: newrelic-infra.yml
+                path: newrelic-infra.yml
+        - name: nri-integrations-cfg-volume
+          configMap:
+            name: {{ include "nriKubernetes.deployment.fullname.integrations" . }}
+        {{- with .Values.deployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with include "nriKubernetes.deployment.affinity" . }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with include "nriKubernetes.deployment.tolerations" . }}
+      tolerations:
+        {{- . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.nodeSelector | default (fromYaml (include "newrelic.common.nodeSelector" .)) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end -}}
+{{- end }}

--- a/charts/newrelic-infrastructure/templates/deployment/integrations-configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/deployment/integrations-configmap.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.deployment.enabled -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "nriKubernetes.deployment.fullname.integrations" . }}
+data:
+  # This ConfigMap holds config files for integrations. They should have the following format:
+  #redis-config.yml: |
+  #  # Run auto discovery to find pods with label "app=redis"
+  #  discovery:
+  #    command:
+  #      # Run discovery for Kubernetes. Use the following optional arguments:
+  #      # --namespaces: Comma separated list of namespaces to discover pods on
+  #      # --tls: Use secure (TLS) connection
+  #      # --port: Port used to connect to the deployment. Default is 10255
+  #      exec: /var/db/newrelic-infra/nri-discovery-kubernetes --port PORT --tls
+  #      match:
+  #        label.app: redis
+  #  integrations:
+  #    - name: nri-redis
+  #      env:
+  #        # using the discovered IP as the hostname address
+  #        HOSTNAME: ${discovery.ip}
+  #        PORT: 6379
+  #        KEYS: '{"0":["<KEY_1>"],"1":["<KEY_2>"]}'
+  #        REMOTE_MONITORING: true
+  #      labels:
+  #        env: production
+  {{- if .Values.integrations -}}
+  {{- range $k, $v := .Values.integrations -}}
+  {{- $k | trimSuffix ".yaml" | trimSuffix ".yml" | nindent 2 -}}.yaml: |-
+  {{- $v | toYaml | nindent 4 -}}
+  {{- end }}
+  {{- end }}
+
+  {{- /* This template will add and template the integrations in the old .Values.integrations_config */}}
+  {{- include "newrelic.compatibility.integrations" . | nindent 2 }}
+
+  {{- /* This template will add Pixie Health check to the integrations */}}
+  {{- if .Values.selfMonitoring.pixie.enabled }}
+  pixie-health-check.yaml: |
+    ---
+    # This Flex config performs periodic checks of the Pixie
+    # /healthz and /statusz endpoints exposed by the Pixie Cloud Connector.
+    # A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
+    #
+    # If Pixie is not installed in the cluster, no events will be generated.
+    # This can also be disabled with enablePixieHealthCheck: false in the values.yaml file.
+    discovery:
+      command:
+        exec: /var/db/newrelic-infra/nri-discovery-kubernetes --tls --port 10250
+        match:
+          label.name: vizier-cloud-connector
+    integrations:
+      - name: nri-flex
+        interval: 60s
+        config:
+          name: pixie-health-check
+          apis:
+            - event_type: pixieHealth
+              commands:
+                - run: curl --insecure -s https://${discovery.ip}:50800/healthz | xargs | awk '{print "cloud_connector_health:"$1}'
+                  split_by: ":"
+              merge: pixieHealthCheck
+            - event_type: pixieStatus
+              commands:
+                - run: curl --insecure -s https://${discovery.ip}:50800/statusz | awk '{if($1 == ""){ print "cloud_connector_status:OK" } else { print "cloud_connector_status:"$1 }}'
+                  split_by: ":"
+              merge: pixieHealthCheck
+  {{- end }}
+{{- end }}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -11,15 +11,8 @@ metadata:
   annotations: {{ . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if eq .Values.kubelet.kind "DaemonSet"}}
   {{- with .Values.updateStrategy }}
   updateStrategy: {{ toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}
-  {{- if eq .Values.kubelet.kind "Deployment"}}
-  {{- with .Values.strategy }}
-  strategy: {{ toYaml . | nindent 4 }}
-  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -11,8 +11,15 @@ metadata:
   annotations: {{ . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if eq .Values.kubelet.kind "DaemonSet"}}
   {{- with .Values.updateStrategy }}
   updateStrategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.kubelet.kind "Deployment"}}
+  {{- with .Values.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if (.Values.kubelet.enabled) }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ .Values.kubelet.kind }}
 metadata:
   namespace: {{ .Release.Namespace }}
   labels:

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if (.Values.kubelet.enabled) }}
 apiVersion: apps/v1
-kind: {{ .Values.kubelet.kind }}
+kind: DaemonSet
 metadata:
   namespace: {{ .Release.Namespace }}
   labels:

--- a/charts/newrelic-infrastructure/templates/kubelet/integrations-configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/integrations-configmap.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.kubelet.enabled -}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -70,3 +72,4 @@ data:
                   split_by: ":"
               merge: pixieHealthCheck
   {{- end }}
+{{- end }}

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -124,7 +124,6 @@ kubelet:
   # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
   annotations: {}
-  kind: DaemonSet
   # -- Tolerations for the control plane DaemonSet.
   # @default -- Schedules in all tainted nodes
   tolerations:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -69,6 +69,54 @@ common:
 # @default -- `false` (See [Low data mode](README.md#low-data-mode))
 lowDataMode:
 
+# deployment -- Configuration for the deployment that collects metrics from the agent for integrations likeexternal rds monitoring.
+# @default -- See `values.yaml`
+deployment:
+  # -- Enable deployment monitoring.
+  enabled: true
+  annotations: {}
+  # -- Tolerations for the control plane Deployment.
+  # @default -- Schedules in all tainted nodes
+  tolerations:
+    - operator: "Exists"
+      effect: "NoSchedule"
+    - operator: "Exists"
+      effect: "NoExecute"
+  nodeSelector: {}
+  affinity: {}
+  # -- Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster.
+  # It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in
+  # [New Relic docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/)
+  # e.g. you can set `passthrough_environment` int the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file)
+  # so the agent let use that environment variables to the integrations.
+  agentConfig: {}
+  # passthrough_environment:
+  #   - A_ENVIRONMENT_VARIABLE_SET_IN_extraEnv
+  #   - A_ENVIRONMENT_VARIABLE_SET_IN_A_CONFIG_MAP_SET_IN_entraEnvForm
+
+  # -- Add user environment variables to the agent
+  extraEnv: []
+  # -- Add user environment from configMaps or secrets as variables to the agent
+  extraEnvFrom: []
+  # -- Volumes to mount in the containers
+  extraVolumes: []
+  # -- Defines where to mount volumes specified with `extraVolumes`
+  extraVolumeMounts: []
+  initContainers: []
+  resources:
+    limits:
+      memory: 300M
+    requests:
+      cpu: 100m
+      memory: 150M
+  config:
+    # -- Timeout for the kubelet APIs contacted by the integration
+    timeout: 10s
+    # -- Number of retries after timeout expired
+    retries: 3
+  # port:
+  # scheme:
+
 # kubelet -- Configuration for the DaemonSet that collects metrics from the Kubelet.
 # @default -- See `values.yaml`
 kubelet:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -76,6 +76,7 @@ kubelet:
   # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
   annotations: {}
+  kind: DaemonSet
   # -- Tolerations for the control plane DaemonSet.
   # @default -- Schedules in all tainted nodes
   tolerations:


### PR DESCRIPTION
In our use case we are trying to setup external RDS monitoring using this infrastructure agent. We do not want the kubelet running as dameonset because it sets up pods on all nodes. To save resources on our cluster we want to be able to deploy it as deployment so that we can control the replicas. 

Currently only controlplane allows this, we would like the kubelet to be able to that as well.