### PR TITLE
update pixie check default

### DIFF
--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -566,7 +566,7 @@ selfMonitoring:
     # selfMonitoring.pixie.enabled -- Enables the Pixie Health Check nri-flex config.
     # This Flex config performs periodic checks of the Pixie /healthz and /statusz endpoints exposed by the Pixie
     # Cloud Connector. A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
-    enabled: true
+    enabled: false
 
 
 # -- Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`. Can be configured also with `global.proxy`


### PR DESCRIPTION
The flex-based Pixie health check config is generating errors and needs to be debugged.  Until I have time to investigate, I think this should be disabled by default so the `pixieHealthCheck` events aren't spammed with useless data.