### PR TITLE
set pixie check to false

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.8.8
+version: 3.8.9
 appVersion: 3.4.2
 
 dependencies:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -567,7 +567,7 @@ selfMonitoring:
     # selfMonitoring.pixie.enabled -- Enables the Pixie Health Check nri-flex config.
     # This Flex config performs periodic checks of the Pixie /healthz and /statusz endpoints exposed by the Pixie
     # Cloud Connector. A status for each endpoint is sent to New Relic in a pixieHealthCheck event.
-    enabled: true
+    enabled: false
 
 
 # -- Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`. Can be configured also with `global.proxy`


### PR DESCRIPTION
@bpschmitt originally posted in PR #553 this:

> Disables the flex-based `pixieHealthCheck` events by default.  There is an error in the flex script syntax that needs to be debugged and it's currently creating noise.  Will re-enable once I get time to fix it.

He opened this PR while GitHub was having an incident and seems to have cached a glitched version of the code/action because it is failing with an action that has has no changes since 8 months ago.

We are recreating manually the PR to test it again.