### PR TITLE
chore: bump chart version and dependencies

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,8 +8,8 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.8.11
-appVersion: 3.4.2
+version: 3.9.0
+appVersion: 3.5.0
 
 dependencies:
   - name: common-library

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -23,14 +23,14 @@ images:
   forwarder:
     registry: ""
     repository: newrelic/k8s-events-forwarder
-    tag: 1.31.0
+    tag: 1.33.1
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Infrastructure Agent plus integrations.
   # @default -- See `values.yaml`
   agent:
     registry: ""
     repository: newrelic/infrastructure-bundle
-    tag: 2.8.31
+    tag: 2.8.33
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Kubernetes integration.
   # @default -- See `values.yaml`


### PR DESCRIPTION
We still need to update `newrelic/infrastructure-bundle` when [this PR](https://github.com/newrelic/infrastructure-bundle/pull/241) is merged.