### PR TITLE
fix(signature): extra parameters were unused

### DIFF
--- a/src/definition/guessfunc.go
+++ b/src/definition/guessfunc.go
@@ -6,7 +6,7 @@ import (
 )
 
 // K8sMetricSetTypeGuesser is the metric set type guesser for k8s integrations.
-func K8sMetricSetTypeGuesser(_, groupLabel, _ string, _ RawGroups) (string, error) {
+func K8sMetricSetTypeGuesser(groupLabel string) (string, error) {
 	var sampleName string
 	for _, s := range strings.Split(groupLabel, "-") {
 		sampleName += strings.Title(s) //nolint: staticcheck // TODO: use golang.org/x/text/cases assuring no breaking changes.

--- a/src/definition/guessfunc_test.go
+++ b/src/definition/guessfunc_test.go
@@ -23,7 +23,7 @@ func TestK8sMetricSetTypeGuesser(t *testing.T) {
 		t.Run(testCase.groupLabel, func(t *testing.T) {
 			t.Parallel()
 
-			guess, err := K8sMetricSetTypeGuesser("", testCase.groupLabel, "", nil)
+			guess, err := K8sMetricSetTypeGuesser(testCase.groupLabel)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expected, guess)
 		})

--- a/src/definition/populate.go
+++ b/src/definition/populate.go
@@ -14,7 +14,7 @@ const NamespaceGroup = "namespace"
 const NamespaceFilteredLabel = "nrFiltered"
 
 // GuessFunc guesses from data.
-type GuessFunc func(clusterName, groupLabel, entityID string, groups RawGroups) (string, error)
+type GuessFunc func(groupLabel string) (string, error)
 
 func populateCluster(i *integration.Integration, clusterName string, k8sVersion fmt.Stringer) error {
 	e, err := i.Entity(clusterName, "k8s:cluster")
@@ -121,7 +121,7 @@ func IntegrationPopulator(config *IntegrationPopulateConfig) (bool, []error) {
 				msTypeGuesser = customGuesser
 			}
 
-			msType, err := msTypeGuesser(config.ClusterName, groupLabel, entityID, config.Groups)
+			msType, err := msTypeGuesser(groupLabel)
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/src/definition/populate_test.go
+++ b/src/definition/populate_test.go
@@ -181,7 +181,7 @@ func fromMultiple(values definition.FetchedValues) definition.FetchFunc {
 }
 
 // fromGroupMetricSetTypeGuessFunc uses the groupLabel for creating the metric set type sample.
-func fromGroupMetricSetTypeGuessFunc(_, groupLabel, _ string, _ definition.RawGroups) (string, error) {
+func fromGroupMetricSetTypeGuessFunc(groupLabel string) (string, error) {
 	return fmt.Sprintf("%vSample", strings.Title(groupLabel)), nil
 }
 
@@ -669,7 +669,7 @@ func TestIntegrationPopulator_EntityTypeGeneratorFuncWithError(t *testing.T) {
 }
 
 func TestIntegrationPopulator_msTypeGuesserFuncWithError(t *testing.T) {
-	msTypeGuesserFuncWithError := func(_, groupLabel, _ string, _ definition.RawGroups) (string, error) {
+	msTypeGuesserFuncWithError := func(groupLabel string) (string, error) {
 		return "", fmt.Errorf("error setting event type")
 	}
 
@@ -738,7 +738,7 @@ func TestIntegrationPopulator_CustomMsTypeGuesser(t *testing.T) { //nolint: para
 	intgr, err := integration.New("nr.test", "1.0.0", integration.InMemoryStore())
 	require.NoError(t, err)
 
-	customMsTypeGuesser := func(_, _, _ string, _ definition.RawGroups) (string, error) {
+	customMsTypeGuesser := func(_ string) (string, error) {
 		return "Custom", nil
 	}
 

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -1331,7 +1331,7 @@ func fetchIfMissing(replacement definition.FetchFunc, main definition.FetchFunc)
 // metricSetTypeGuesserWithCustomGroup customizes K8sMetricSetTypeGuesser by setting up a custom value instead of the
 // groupLabel.
 func metricSetTypeGuesserWithCustomGroup(group string) definition.GuessFunc {
-	return func(clusterName, groupLabel, entityID string, groups definition.RawGroups) (string, error) {
-		return definition.K8sMetricSetTypeGuesser(clusterName, group, entityID, groups) //nolint: wrapcheck
+	return func(_ string) (string, error) {
+		return definition.K8sMetricSetTypeGuesser(group) //nolint: wrapcheck
 	}
 }

--- a/src/metric/definition_test.go
+++ b/src/metric/definition_test.go
@@ -236,7 +236,7 @@ func TestMetricSetTypeGuesserWithCustomGroup(t *testing.T) {
 		t.Run(testCase.groupLabel, func(t *testing.T) {
 			t.Parallel()
 
-			guess, err := metricSetTypeGuesserWithCustomGroup("custom")("", testCase.groupLabel, "", nil)
+			guess, err := metricSetTypeGuesserWithCustomGroup("custom")(testCase.groupLabel)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, guess)
 		})


### PR DESCRIPTION
The signature could be reduced, but I would even get rid of the whole function if possible