### PR TITLE
Update e2e testing to support k8s v1.25

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,9 +48,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.0
+        uses: manusa/actions-setup-minikube@v2.7.1
         with:
-          minikube version: v1.26.0
+          minikube version: v1.28.0
           kubernetes version: ${{ matrix.k8sVersion }}
           driver: docker
           start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"
@@ -77,7 +77,7 @@ jobs:
             echo "::set-output name=exceptions::1_22"
           elif [ "$MINOR" -eq 23 ]; then
             echo "::set-output name=exceptions::1_23"
-          elif [ "$MINOR" -ge 24 ]; then
+          elif [ "$MINOR" -eq 24 ]; then
             echo "::set-output name=exceptions::1_24"
           elif [ "$MINOR" -ge 25 ]; then
             echo "::set-output name=exceptions::1_25"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 make compile # Set GOOS and GOARCH explicitly since Dockerfile expects them in the binary name
           docker build -t e2e/nri-kubernetes:e2e  .
-          minikube ima ge load e2e/nri-kubernetes:e2e
+          minikube image load e2e/nri-kubernetes:e2e
       - name: Setup Helm
         run: |
           chmod go-r /home/runner/.kube/config

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,15 +18,19 @@ jobs:
       matrix:
         # Latest patch version can be found in https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
         # Some versions might not be available yet in https://storage.googleapis.com/kubernetes-release/release/v1.X.Y/bin/linux/amd64/kubelet
-        k8sVersion: [ "v1.24.1","v1.23.8","v1.22.11", "v1.21.14", "v1.16.15" ]
+        k8sVersion: [ "v1.25.3", "v1.24.1", "v1.23.8", "v1.22.11", "v1.21.14", "v1.16.15" ]
         cri: [ docker ]
         exclude:
           - k8sVersion: v1.24.1
+            cri: docker
+          - k8sVersion: v1.25.3
             cri: docker
         include:
           - k8sVersion: v1.24.1
             cri: containerd
           - k8sVersion: v1.23.8
+            cri: containerd
+          - k8sVersion: v1.25.3
             cri: containerd
     env:
       DOCKER_BUILDKIT: '1' # Setting DOCKER_BUILDKIT=1 ensures TARGETOS and TARGETARCH are populated
@@ -44,7 +48,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.6.0
+        uses: manusa/actions-setup-minikube@v2.7.0
         with:
           minikube version: v1.26.0
           kubernetes version: ${{ matrix.k8sVersion }}
@@ -57,7 +61,7 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 make compile # Set GOOS and GOARCH explicitly since Dockerfile expects them in the binary name
           docker build -t e2e/nri-kubernetes:e2e  .
-          minikube image load e2e/nri-kubernetes:e2e
+          minikube ima ge load e2e/nri-kubernetes:e2e
       - name: Setup Helm
         run: |
           chmod go-r /home/runner/.kube/config
@@ -73,8 +77,10 @@ jobs:
             echo "::set-output name=exceptions::1_22"
           elif [ "$MINOR" -eq 23 ]; then
             echo "::set-output name=exceptions::1_23"
-          elif [ "$MINOR" -ge 24 ]; then 
+          elif [ "$MINOR" -ge 24 ]; then
             echo "::set-output name=exceptions::1_24"
+          elif [ "$MINOR" -ge 25 ]; then
+            echo "::set-output name=exceptions::1_25"
           fi
       - name: Run e2e-test
         uses: newrelic/newrelic-integration-e2e-action@v1

--- a/e2e/1_25-exceptions.yml
+++ b/e2e/1_25-exceptions.yml
@@ -1,4 +1,4 @@
-# This metrics are not present on 1.24
+# This metrics are not present on 1.25
 except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*

--- a/e2e/1_25-exceptions.yml
+++ b/e2e/1_25-exceptions.yml
@@ -1,0 +1,13 @@
+# This metrics are not present on 1.24
+except_metrics:
+# removed from 1.23
+- k8s.apiserver.etcd.objectCount_*
+
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.controllermanager.nodeCollectorEvictionsDelta
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating
+- k8s.scheduler.schedulerPendingPodsActive
+- k8s.scheduler.schedulerPendingPodsBackoff
+- k8s.scheduler.schedulerPendingPodsUnschedulable
+- k8s.apiserver.storageObjects_*


### PR DESCRIPTION
This PR updates the e2e testing to support K8s v1.25 by doing the following:
- Update `e2e.yaml` to include new K8s version
- Add exceptions file for v1.25 (using same exceptions as v1.24). 