### PR TITLE
Update hostnetwork configuration for ksm deployment

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.10.1
+version: 3.11.0
 appVersion: 3.6.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.10.0
+version: 3.10.1
 appVersion: 3.6.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -153,6 +153,7 @@ integrations that you have configured.
 | ksm.config.selector | string | `"app.kubernetes.io/name=kube-state-metrics"` | Label selector that will be used to automatically discover an instance of kube-state-metrics running in the cluster. |
 | ksm.config.timeout | string | `"10s"` | Timeout for the ksm API contacted by the integration |
 | ksm.enabled | bool | `true` | Enable cluster state monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
+| ksm.hostNetwork | bool | `false` | Sets pod's hostNetwork. When set bypasses global/common variable  @default ==  `false` |
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
 | ksm.tolerations | list | Schedules in all tainted nodes | Tolerations for the KSM Deployment. |
 | kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
@@ -164,6 +165,7 @@ integrations that you have configured.
 | kubelet.extraEnvFrom | list | `[]` | Add user environment from configMaps or secrets as variables to the agent |
 | kubelet.extraVolumeMounts | list | `[]` | Defines where to mount volumes specified with `extraVolumes` |
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
+| kubelet.hostNetwork | bool | `false` | Sets pod's hostNetwork. When set bypasses global/common variable  @default ==  `false` |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |
@@ -179,7 +181,7 @@ integrations that you have configured.
 | proxy | string | `""` | Configures the integration to send all HTTP/HTTPS request through the proxy in that URL. The URL should have a standard format like `https://user:password@hostname:port`. Can be configured also with `global.proxy` |
 | rbac.create | bool | `true` | Whether the chart should automatically create the RBAC objects required to run. |
 | rbac.pspEnabled | bool | `false` | Whether the chart should create Pod Security Policy objects. |
-| selfMonitoring.pixie.enabled | bool | `true` | Enables the Pixie Health Check nri-flex config. This Flex config performs periodic checks of the Pixie /healthz and /statusz endpoints exposed by the Pixie Cloud Connector. A status for each endpoint is sent to New Relic in a pixieHealthCheck event. |
+| selfMonitoring.pixie.enabled | bool | `false` | Enables the Pixie Health Check nri-flex config. This Flex config performs periodic checks of the Pixie /healthz and /statusz endpoints exposed by the Pixie Cloud Connector. A status for each endpoint is sent to New Relic in a pixieHealthCheck event. |
 | serviceAccount | object | See `values.yaml` | Settings controlling ServiceAccount creation. |
 | serviceAccount.create | bool | `true` | Whether the chart should automatically create the ServiceAccount objects required to run. |
 | strategy | object | `type: Recreate` | Update strategy for the deployed Deployments. |

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -153,7 +153,7 @@ integrations that you have configured.
 | ksm.config.selector | string | `"app.kubernetes.io/name=kube-state-metrics"` | Label selector that will be used to automatically discover an instance of kube-state-metrics running in the cluster. |
 | ksm.config.timeout | string | `"10s"` | Timeout for the ksm API contacted by the integration |
 | ksm.enabled | bool | `true` | Enable cluster state monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
-| ksm.hostNetwork | bool | `false` | Sets pod's hostNetwork. When set bypasses global/common variable  @default ==  `false` |
+| ksm.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable  |
 | ksm.resources | object | 100m/150M -/850M | Resources for the KSM scraper pod. Keep in mind that sharding is not supported at the moment, so memory usage for this component ramps up quickly on large clusters. |
 | ksm.tolerations | list | Schedules in all tainted nodes | Tolerations for the KSM Deployment. |
 | kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
@@ -165,7 +165,7 @@ integrations that you have configured.
 | kubelet.extraEnvFrom | list | `[]` | Add user environment from configMaps or secrets as variables to the agent |
 | kubelet.extraVolumeMounts | list | `[]` | Defines where to mount volumes specified with `extraVolumes` |
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
-| kubelet.hostNetwork | bool | `false` | Sets pod's hostNetwork. When set bypasses global/common variable  @default ==  `false` |
+| kubelet.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable  |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |

--- a/charts/newrelic-infrastructure/templates/ksm/_host_network.tpl
+++ b/charts/newrelic-infrastructure/templates/ksm/_host_network.tpl
@@ -1,0 +1,22 @@
+{{/* Returns whether the ksm scraper should run with hostNetwork: true based on the user configuration. */}}
+{{- define "nriKubernetes.ksm.hostNetwork" -}}
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if get .Values.ksm "hostNetwork" | kindIs "bool" -}}
+    {{- if .Values.ksm.hostNetwork -}}
+        {{- .Values.ksm.hostNetwork -}}
+    {{- end -}}
+{{- else if include "newrelic.common.hostNetwork" . -}}
+    {{- include "newrelic.common.hostNetwork" . -}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{/* Abstraction of "nriKubernetes.ksm.hostNetwork" that returns true of false directly */}}
+{{- define "nriKubernetes.ksm.hostNetwork.value" -}}
+{{- if include "nriKubernetes.ksm.hostNetwork" . -}}
+    true
+{{- else -}}
+    false
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       hostNetwork: {{ include "nriKubernetes.ksm.hostNetwork.value" . }}
-      {{- if include "nriKubernetes.controlPlane.hostNetwork" . }}
+      {{- if include "nriKubernetes.ksm.hostNetwork" . }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -49,11 +49,11 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
-      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
+      hostNetwork: {{ include "nriKubernetes.ksm.hostNetwork.value" . }}
       {{- if include "nriKubernetes.controlPlane.hostNetwork" . }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
-
+      
       {{- if .Values.ksm.initContainers }}
       initContainers: {{- tpl (.Values.ksm.initContainers | toYaml) . | nindent 8 }}
       {{- end }}

--- a/charts/newrelic-infrastructure/templates/kubelet/_host_network.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_host_network.tpl
@@ -1,0 +1,22 @@
+{{/* Returns whether the kubelet scraper should run with hostNetwork: true based on the user configuration. */}}
+{{- define "nriKubernetes.kubelet.hostNetwork" -}}
+{{- /* `get` will return "" (empty string) if value is not found, and the value otherwise, so we can type-assert with kindIs */ -}}
+{{- if get .Values.kubelet "hostNetwork" | kindIs "bool" -}}
+    {{- if .Values.kubelet.hostNetwork -}}
+        {{- .Values.kubelet.hostNetwork -}}
+    {{- end -}}
+{{- else if include "newrelic.common.hostNetwork" . -}}
+    {{- include "newrelic.common.hostNetwork" . -}}
+{{- end -}}
+{{- end -}}
+
+
+
+{{/* Abstraction of "nriKubernetes.kubelet.hostNetwork" that returns true of false directly */}}
+{{- define "nriKubernetes.kubelet.hostNetwork.value" -}}
+{{- if include "nriKubernetes.kubelet.hostNetwork" . -}}
+    true
+{{- else -}}
+    false
+{{- end -}}
+{{- end -}}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -50,8 +50,8 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
-      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
-      {{- if include "nriKubernetes.controlPlane.hostNetwork" . }}
+      hostNetwork: {{ include "nriKubernetes.kubelet.hostNetwork.value" . }}
+      {{- if include "nriKubernetes.kubelet.hostNetwork" . }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
 

--- a/charts/newrelic-infrastructure/tests/hostNetwork_test.yaml
+++ b/charts/newrelic-infrastructure/tests/hostNetwork_test.yaml
@@ -157,27 +157,6 @@ tests:
           value: true
         template: templates/kubelet/daemonset.yaml
 
-  - it: hostNetwork is set by the common library
-    set:
-      licenseKey: test
-      cluster: test
-      global.hostNetwork: null
-      hostNetwork: true
-      ksm.hostNetwork: null
-    asserts:
-      - equal:
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: templates/ksm/deployment.yaml
-      - equal:
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: templates/controlplane/daemonset.yaml
-      - equal:
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: templates/kubelet/daemonset.yaml
-
   - it: kubelet hostNetwork is overridable to true
     set:
       licenseKey: test
@@ -219,25 +198,3 @@ tests:
           path: spec.template.spec.hostNetwork
           value: true
         template: templates/kubelet/daemonset.yaml
-
-  - it: hostNetwork is set by the common library
-    set:
-      licenseKey: test
-      cluster: test
-      global.hostNetwork: null
-      hostNetwork: true
-      kubelet.hostNetwork: null
-    asserts:
-      - equal:
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: templates/ksm/deployment.yaml
-      - equal:
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: templates/controlplane/daemonset.yaml
-      - equal:
-          path: spec.template.spec.hostNetwork
-          value: true
-        template: templates/kubelet/daemonset.yaml
-

--- a/charts/newrelic-infrastructure/tests/hostNetwork_test.yaml
+++ b/charts/newrelic-infrastructure/tests/hostNetwork_test.yaml
@@ -188,7 +188,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.hostNetwork
-          value: false
+          value: true
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.hostNetwork
@@ -196,5 +196,5 @@ tests:
         template: templates/controlplane/daemonset.yaml
       - equal:
           path: spec.template.spec.hostNetwork
-          value: true
+          value: false
         template: templates/kubelet/daemonset.yaml

--- a/charts/newrelic-infrastructure/tests/hostNetwork_test.yaml
+++ b/charts/newrelic-infrastructure/tests/hostNetwork_test.yaml
@@ -114,3 +114,130 @@ tests:
           path: spec.template.spec.hostNetwork
           value: true
         template: templates/kubelet/daemonset.yaml
+
+  - it: ksm hostNetwork is overridable to true
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: false
+      ksm.hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/ksm/deployment.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/controlplane/daemonset.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/kubelet/daemonset.yaml
+
+  - it: ksm hostNetwork is overridable to false
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: true
+      ksm.hostNetwork: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/ksm/deployment.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/controlplane/daemonset.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/kubelet/daemonset.yaml
+
+  - it: hostNetwork is set by the common library
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: true
+      ksm.hostNetwork: null
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/ksm/deployment.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/controlplane/daemonset.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/kubelet/daemonset.yaml
+
+  - it: kubelet hostNetwork is overridable to true
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: false
+      kubelet.hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/ksm/deployment.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/controlplane/daemonset.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/kubelet/daemonset.yaml
+
+  - it: kubelet hostNetwork is overridable to false
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: true
+      kubelet.hostNetwork: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: templates/ksm/deployment.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/controlplane/daemonset.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/kubelet/daemonset.yaml
+
+  - it: hostNetwork is set by the common library
+    set:
+      licenseKey: test
+      cluster: test
+      global.hostNetwork: null
+      hostNetwork: true
+      kubelet.hostNetwork: null
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/ksm/deployment.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/controlplane/daemonset.yaml
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: templates/kubelet/daemonset.yaml
+

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -84,6 +84,9 @@ kubelet:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
+  # -- (bool) Sets pod's hostNetwork. Uncomment to configure hostnetwork to ksm deployment only, bypasses global/common variable 
+  # @default ==  `global.hostNetwork`
+  #hostNetwork: false
   affinity: {}
   # -- Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster.
   # It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -84,7 +84,7 @@ kubelet:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
-  # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable 
+  # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable
   # @default -- Not set
   hostNetwork:
   affinity: {}
@@ -136,7 +136,7 @@ ksm:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
-  # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable 
+  # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable
   # @default -- Not set
   hostNetwork:
   # -- Affinity for the KSM Deployment.

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -137,8 +137,8 @@ ksm:
       effect: "NoExecute"
   nodeSelector: {}
   # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable 
-  # @default ==  `false`
-  hostNetwork: false
+  # @default -- Not set
+  hostNetwork:
   # -- Affinity for the KSM Deployment.
   # @default -- Deployed in the same node as KSM
   affinity:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -85,8 +85,8 @@ kubelet:
       effect: "NoExecute"
   nodeSelector: {}
   # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable 
-  # @default ==  `false`
-  hostNetwork: false
+  # @default -- Not set
+  hostNetwork:
   affinity: {}
   # -- Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster.
   # It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -84,9 +84,9 @@ kubelet:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
-  # -- (bool) Sets pod's hostNetwork. Uncomment to configure hostnetwork to ksm deployment only, bypasses global/common variable 
-  # @default ==  `global.hostNetwork`
-  #hostNetwork: false
+  # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable 
+  # @default ==  `false`
+  hostNetwork: false
   affinity: {}
   # -- Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster.
   # It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in
@@ -136,9 +136,9 @@ ksm:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
-  # -- (bool) Sets pod's hostNetwork. Uncomment to configure hostnetwork to ksm deployment only, bypasses global/common variable 
-  # @default ==  `global.hostNetwork`
-  #hostNetwork: false
+  # -- (bool) Sets pod's hostNetwork. When set bypasses global/common variable 
+  # @default ==  `false`
+  hostNetwork: false
   # -- Affinity for the KSM Deployment.
   # @default -- Deployed in the same node as KSM
   affinity:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -133,6 +133,9 @@ ksm:
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}
+  # -- (bool) Sets pod's hostNetwork. Uncomment to configure hostnetwork to ksm deployment only, bypasses global/common variable 
+  # @default ==  `global.hostNetwork`
+  #hostNetwork: false
   # -- Affinity for the KSM Deployment.
   # @default -- Deployed in the same node as KSM
   affinity:


### PR DESCRIPTION
KSM does not required hostnetwork by default, apart from some corner use cases.
Currently if we disable hostnetwork it will also disable to kubelet as hostnetwork is set by global/common variable
This PR makes it configurable, if hostnetwork is set in values it will be used otherwise it will still use global/common variable 
There are various ways to tackle this and you may choose different one, but please consider making ksm hostnetwork independently configurable

---
Context added by @roobre: This would allow to deploy the `kubelet` scraper with `hostNetwork` enabled while keeping it off for the rest. The main motivation for this is to be able to access [AWS Metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html) when it is [limited to 1 hop only](https://docs.aws.amazon.com/config/latest/developerguide/ec2-token-hop-limit-check.html), which is the recommended value from AWS.