### PR TITLE
Bump chart version and dependencies

### DIFF
--- a/.github/workflows/nightlyAndMainImage.yml
+++ b/.github/workflows/nightlyAndMainImage.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           path: bin
 
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
           password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: bin
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           username: ${{ secrets.FSI_DOCKERHUB_USERNAME }}
           password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.11.1
+version: 3.12.0
 appVersion: 3.6.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -23,14 +23,14 @@ images:
   forwarder:
     registry: ""
     repository: newrelic/k8s-events-forwarder
-    tag: 1.33.2
+    tag: 1.36.1
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Infrastructure Agent plus integrations.
   # @default -- See `values.yaml`
   agent:
     registry: ""
     repository: newrelic/infrastructure-bundle
-    tag: 2.8.34
+    tag: 2.8.38
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Kubernetes integration.
   # @default -- See `values.yaml`


### PR DESCRIPTION
Ping new version of infra bundle that solves some vulns; you can follow the conversation [here](https://newrelic.slack.com/archives/CP2EWSX7C/p1673970141838969). Leveraged and updated some other dependencies.