### PR TITLE
matchExpressions values need to be string now

### DIFF
--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -57,7 +57,7 @@ common:
     # Otherwise you can build more complex filters and include or exclude certain namespaces by adding one or multiple
     # expressions that are added, for instance:
     # matchExpressions:
-    #   - {key: newrelic.com/scrape, operator: NotIn, values: [false]}
+    #   - {key: newrelic.com/scrape, operator: NotIn, values: ["false"]}
 
   # -- Config for the Infrastructure agent.
   # Will be used by the forwarder sidecars and the agent running integrations.


### PR DESCRIPTION
Just ran into copying and pasting this example and received `invalid matchExpressions value: false, type: bool`

It has been changed with the PR https://github.com/newrelic/nri-kubernetes/pull/495,