### PR TITLE
Update E2E testing with CronJob

### DIFF
--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -2535,6 +2535,770 @@ entities:
       - event_type
       - provider
       - networkTag.*
+  - entityType: K8sCronjob
+    metrics:
+      - name: k8s.cronjob.createdAt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - createdAt
+      - name: k8s.cronjob.isActive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - isActive
+      - name: k8s.cronjob.nextScheduledTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - nextScheduledTime
+      - name: k8s.cronjob.lastScheduledTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - lastScheduledTime
+      - name: k8s.cronjob.isSuspended
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - isSuspended
+      - name: k8s.cronjob.specStartingDeadlineSeconds
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - specStartingDeadlineSeconds
+      - name: k8s.cronjob.metadataResourceVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - metadataResourceVersion
+    tags:
+      - name: k8s.clusterName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - clusterName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: k8s.namespaceName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - namespaceName
+            - namespace
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: k8s.cronjobName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - cronjobName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: entity.guid
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityGuid
+            - nr.entityGuid
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: entity.name
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: entity.id
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: tags.*
+        type: string
+        description: >-
+          These are user-defined tags (* matches any value configured by the customer)
+        migrationInformation:
+          legacyNames:
+            - label.*
+            - ec2Tag_*
+            - provider.ec2Tag_*
+            - tag_*
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: tags.container.*
+        type: string
+        description: >-
+          These are user-defined tags (* matches any value configured by the customer)
+        migrationInformation:
+          legacyNames:
+            - containerLabel_*
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.kernelVersion
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - kernelVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.linuxDistribution
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - linuxDistribution
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.operatingSystem
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - operatingSystem
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.windowsFamily
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsFamily
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.windowsPlatform
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsPlatform
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.windowsVersion
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.instanceType
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - instanceType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.hostname
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - hostname
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.fullHostname
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - fullHostname
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.region
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsRegion
+            - provider.awsRegion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.accountId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsAccountId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.availabilityZone
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsAvailabilityZone
+            - provider.awsAvailabilityZone
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.InstanceId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2InstanceId
+            - provider.ec2InstanceId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.publicDnsName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PublicDnsName
+            - provider.ec2PublicDnsName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.state
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2State
+            - provider.ec2State
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.ebsOptimized
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2EbsOptimized
+            - provider.ec2EbsOptimized
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.publicIpAddress
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PublicIpAddress
+            - provider.ec2PublicIpAddress
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.privateIpAddress
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PrivateIpAddress
+            - provider.ec2PrivateIpAddress
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.vpcId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2VpcId
+            - provider.ec2VpcId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.amiId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2AmiId
+            - provider.ec2AmiId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.privateDnsName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PrivateDnsName
+            - provider.ec2PrivateDnsName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.keyName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2KeyName
+            - provider.ec2KeyName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.subnetId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2SubnetId
+            - provider.ec2SubnetId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.instanceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2InstanceType
+            - provider.ec2InstanceType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.hypervisor
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2Hypervisor
+            - provider.ec2Hypervisor
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.architecture
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2Architecture
+            - provider.ec2Architecture
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.rootDeviceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2RootDeviceType
+            - provider.ec2RootDeviceType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.rootDeviceName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2RootDeviceName
+            - provider.ec2RootDeviceName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.virtualizationType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2VirtualizationType
+            - provider.ec2VirtualizationType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.placementGroupName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PlacementGroupName
+            - provider.ec2PlacementGroupName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.placementGroupTenancy
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PlacementGroupTenancy
+            - provider.ec2PlacementGroupTenancy
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.arn
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - aws.arn
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.subscriptionId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - subscriptionId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.vmId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - vmId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.vmSize
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - vmSize
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.image
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - image
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.availabilitySet
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - availabilitySet
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.resourceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - type
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.region
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - regionName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.resourceGroup
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - resourceGroupName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.compute.machineType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - machineType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.compute.isPreemptible
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - isPreemptible
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.projectId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - projectId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.zone
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - zone
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.compute.status
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - status
+          legacyEventTypes:
+            - K8sCronjobSample
+    internalAttributes:
+      - name: newrelic.integrationName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - integrationName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.integrationVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - integrationVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.agentVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - agentVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.reportingAgent
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingAgent
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.reportingEndpoint
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingEndpoint
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.reportingEntityKey
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingEntityKey
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.hostId
+        type: string
+        migrationInformation:
+          legacyNames:
+            - hostID
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.countersSource
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - countersSource
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.entityAndPid
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndPid
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.entityAndMountPoint
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndMountPoint
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.entityAndInterface
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndInterface
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.integrationId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - dataSourceId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.integrationName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - dataSourceName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.providerAccountId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerAccountId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.providerAccountName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerAccountName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.providerExternalId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerExternalId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: nr.cloudVmType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - nr.cloudVmType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: nr.performanceMetricsEnabled
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - nr.performanceMetricsEnabled
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.apmApplicationNames
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - apmApplicationNames
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.apmApplicationIds
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - apmApplicationIds
+          legacyEventTypes:
+            - K8sCronjobSample
+    ignoredAttributes:
+      - agentName
+      - coreCount
+      - processorCount
+      - systemMemoryBytes
+      - entityKey
+      - externalKey
+      - warningViolationCount
+      - criticalViolationCount
+      - displayName
+      - event_type
+      - provider
+      - networkTag.*
   - entityType: K8sDaemonset
     metrics:
       - name: k8s.daemonset.createdAt


### PR DESCRIPTION
The Kubernetes team is working on adding new metrics for all Kubernetes workloads, including CronJob: https://issues.newrelic.com/browse/NR-82569.

- Add metrics in `nri-kubernetes` [PR](https://github.com/newrelic/nri-kubernetes/pull/609)
- Update `infra-integration-specs` [PR](https://source.datanerd.us/infrastructure/infra-integration-specs/pull/302)
- Update `infra-metrics-utils` [PR](https://source.datanerd.us/infrastructure/infra-metrics-utils/pull/79)
- Update `dirac` [PR](https://source.datanerd.us/dirac/dirac/pull/7844)

This PR updates the e2e integration spec used in testing. This file is a direct copy of the file updated in the `infra-integration-specs` [PR](https://source.datanerd.us/infrastructure/infra-integration-specs/pull/302).

⚠️ Note that this PR won't pass e2e testing until the backed PRs are merged. This is because e2e testing uses a `keyset()` query and so until the metrics are shimmed from Sample metrics to Dimensional metrics, the keyset won't find them. 

