### PR TITLE
Fix datagen.sh

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -72,25 +72,6 @@ jobs:
           helm repo add newrelic https://helm-charts.newrelic.com
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo update
-      - name: Install kube-state-metrics service onto test the Minikube cluster
-
-        # Starting from k8s v1.26, @autoscaling/v2beta2 API is no longer available as @autoscaling/v2 replaced it. It is important that
-        # kube-state-metrics v2.7.0 is installed on the k8s v1.26.0+ test cluster because only kube-state-metrics v2.7.0 or higher can
-        # supports the @autoscaling/v2 API. The following scripts make sure the correct version of kube-state-metrics is installed in respect
-        # to the k8s version. Incorrect setup will result in missing metrics, for examples: HorizontalPodAutoscaler related metrics .etc .
-
-        # Notes: 
-        # - The kube-state-metrics chart v4.25.0 directly maps to kube-state-metrics application v2.7.0.
-        # - The kube-state-metrics chart v4.23.0 directly maps to kube-state-metrics application v2.6.0.
-        run: |
-          MINOR=$(echo "${{ matrix.k8sVersion }}"|sed -e 's_v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_\2_')
-
-          if [ "$MINOR" -le 25 ]; then
-            KSM_CHART_VERSION="--version v4.23.0"
-          fi
-
-          helm install prometheus-community/kube-state-metrics $KSM_CHART_VERSION --generate-name
-
       - name: Select metrics exception file
         id: exceptions-version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ local-env-start:
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm dependency update ./charts/newrelic-infrastructure
 	helm dependency update ./charts/internal/e2e-resources
-	helm install prometheus-community/kube-state-metrics --generate-name
 	$(MAKE) tilt-up
 
 .PHONY: tilt-up

--- a/charts/internal/e2e-resources/Chart.yaml
+++ b/charts/internal/e2e-resources/Chart.yaml
@@ -3,6 +3,11 @@ version: 1.3.0-devel
 description: This chart creates e2e resources for nri-kubernetes.
 name: e2e-resources
 
+dependencies:
+  - name: kube-state-metrics
+    version: 4.23.0
+    repository: https://prometheus-community.github.io/helm-charts
+
 maintainers:
   - name: alvarocabanas
     url: https://github.com/alvarocabanas

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,15 +10,6 @@ minikube start --kubernetes-version=vX.X.X --container-runtime=containerd
 minikube addons enable metrics-server
 ```
 
-Manually install Kube State Metrics (KSM) service onto the test cluster.
-
-```shell
-helm install prometheus-community/kube-state-metrics --version v4.23.0 --generate-name
-
-NOTE: Starting from k8s v1.26, @autoscaling/v2beta2 API is no longer available as @autoscaling/v2 replaced it. It is important that kube-state-metrics v2.7.0 is installed on the k8s v1.26.0+ test cluster because only kube-state-metrics v2.7.0 or higher can supports the @autoscaling/v2 API. Because of this, if you are running the e2e tests on a k8s v1.26.0 or later cluster, you want to install the prometheus-community/kube-state-metrics chart v4.25.0 instead. Incorrect setup will result in missing metrics, for examples: HorizontalPodAutoscaler related metrics .etc
-```
-
-
 Note that the control plane flags in `e2e-values.yml` have been set meeting the minikube specifications. 
 
 Then you need to build the binary and the image. Notice that  since the Dockerfile includes multiarch

--- a/e2e/test-specs.yml
+++ b/e2e/test-specs.yml
@@ -9,8 +9,8 @@ scenarios:
     before:
       - helm dependency update ../charts/internal/e2e-resources
       - helm dependency update ../charts/newrelic-infrastructure
-      - helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true
-      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set global.nrStaging=true
+      - function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION}
+      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-infrastructure -n nr-${SCENARIO_TAG} --all-containers --prefix=true
       - kubectl get pods -n nr-${SCENARIO_TAG}
@@ -51,8 +51,8 @@ scenarios:
     before:
       - helm dependency update ../charts/internal/e2e-resources
       - helm dependency update ../charts/newrelic-infrastructure
-      - helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true
-      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set privileged=false --set global.nrStaging=true
+      - function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION} 
+      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set privileged=false
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-infrastructure -n nr-${SCENARIO_TAG} --all-containers --prefix=true
       - kubectl get pods -n nr-${SCENARIO_TAG}

--- a/e2e/test-specs.yml
+++ b/e2e/test-specs.yml
@@ -9,7 +9,7 @@ scenarios:
     before:
       - helm dependency update ../charts/internal/e2e-resources
       - helm dependency update ../charts/newrelic-infrastructure
-      - function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION}
+      - function ver { printf $((10#$(printf "%03d%03d" $(echo "$1" | tr '.' ' ')))); } && K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION}
       - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-infrastructure -n nr-${SCENARIO_TAG} --all-containers --prefix=true
@@ -51,7 +51,7 @@ scenarios:
     before:
       - helm dependency update ../charts/internal/e2e-resources
       - helm dependency update ../charts/newrelic-infrastructure
-      - function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION} 
+      - function ver { printf $((10#$(printf "%03d%03d" $(echo "$1" | tr '.' ' ')))); } && K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION} 
       - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set privileged=false
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-infrastructure -n nr-${SCENARIO_TAG} --all-containers --prefix=true

--- a/e2e/test-specs.yml
+++ b/e2e/test-specs.yml
@@ -10,7 +10,7 @@ scenarios:
       - helm dependency update ../charts/internal/e2e-resources
       - helm dependency update ../charts/newrelic-infrastructure
       - helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true
-      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG}
+      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set global.nrStaging=true
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-infrastructure -n nr-${SCENARIO_TAG} --all-containers --prefix=true
       - kubectl get pods -n nr-${SCENARIO_TAG}
@@ -52,7 +52,7 @@ scenarios:
       - helm dependency update ../charts/internal/e2e-resources
       - helm dependency update ../charts/newrelic-infrastructure
       - helm upgrade --install ${SCENARIO_TAG}-resources -n nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true
-      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set privileged=false
+      - helm upgrade --install ${SCENARIO_TAG} -n nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set privileged=false --set global.nrStaging=true
     after:
       - kubectl logs -l app.kubernetes.io/name=newrelic-infrastructure -n nr-${SCENARIO_TAG} --all-containers --prefix=true
       - kubectl get pods -n nr-${SCENARIO_TAG}

--- a/internal/testutil/datagen/datagen.sh
+++ b/internal/testutil/datagen/datagen.sh
@@ -142,8 +142,8 @@ function bootstrap() {
 
         echo "Updating helm dependencies"
 
-        function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && \
-        K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && \
+        function ver { printf $((10#$(printf "%03d%03d" $(echo "$1" | tr '.' ' ')))); }
+        K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }')
         if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi
         
         helm dependency update $helm_e2e_path > /dev/null

--- a/internal/testutil/datagen/datagen.sh
+++ b/internal/testutil/datagen/datagen.sh
@@ -141,10 +141,16 @@ function bootstrap() {
         fi
 
         echo "Updating helm dependencies"
+
+        function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && \
+        K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && \
+        if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi
+        
         helm dependency update $helm_e2e_path > /dev/null
         helm upgrade --install e2e $helm_e2e_path -n $scrapper_namespace --create-namespace \
           --set scraper.enabled=true \
           --set persistentVolume.enabled=true \
+          --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION} \
           $minikube_args \
           $HELM_E2E_ARGS
 


### PR DESCRIPTION
In order to fix KSM and k8s versions incompatibility in e2e tests, the change in this [PR](https://github.com/newrelic/nri-kubernetes/pull/595) disabled KSM auto installation. As a result, CI scripts that ran e2e tests had to detect which k8s version  running and manually install the correct KSM version. Even though this pattern made all e2e tests to pass, but it affect the `datagen.sh` script to set up correct environment. This PR is to fix this issue.

This PR put back KSM auto installation feature, but still allow correct KSM version installation by adding back the KSM dependency in the charts/internal/e2e-resources/Chart.yaml file and making use of `--set kube-state-metrics.image.tag` in helm command.