### PR TITLE
chore(deps): bump alpine from 3.16.2 to 3.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.17.1
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Dependabot PRs don't work with E2E testing. Recreating https://github.com/newrelic/nri-kubernetes/pull/600 so that we can run E2E tests. 