### PR TITLE
[Cleanup] Remove E2E metric exceptions

### DIFF
--- a/e2e/1_23-exceptions.yml
+++ b/e2e/1_23-exceptions.yml
@@ -5,11 +5,3 @@ except_metrics:
 # Added from 1.24
 - k8s.controllermanager.nodeCollectorEvictionsDelta
 - k8s.container.oomEventsDelta
-
-# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
-- k8s.apiserver.currentInflightRequestsReadOnly
-- k8s.apiserver.currentInflightRequestsMutating
-- k8s.scheduler.schedulerPendingPodsActive
-- k8s.scheduler.schedulerPendingPodsBackoff
-- k8s.scheduler.schedulerPendingPodsUnschedulable
-- k8s.apiserver.storageObjects_*

--- a/e2e/1_23-exceptions.yml
+++ b/e2e/1_23-exceptions.yml
@@ -5,3 +5,7 @@ except_metrics:
 # Added from 1.24
 - k8s.controllermanager.nodeCollectorEvictionsDelta
 - k8s.container.oomEventsDelta
+
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating

--- a/e2e/1_24-exceptions.yml
+++ b/e2e/1_24-exceptions.yml
@@ -2,12 +2,3 @@
 except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*
-
-# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
-- k8s.controllermanager.nodeCollectorEvictionsDelta
-- k8s.apiserver.currentInflightRequestsReadOnly
-- k8s.apiserver.currentInflightRequestsMutating
-- k8s.scheduler.schedulerPendingPodsActive
-- k8s.scheduler.schedulerPendingPodsBackoff
-- k8s.scheduler.schedulerPendingPodsUnschedulable
-- k8s.apiserver.storageObjects_*

--- a/e2e/1_24-exceptions.yml
+++ b/e2e/1_24-exceptions.yml
@@ -2,3 +2,7 @@
 except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*
+
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating

--- a/e2e/1_25-exceptions.yml
+++ b/e2e/1_25-exceptions.yml
@@ -2,12 +2,3 @@
 except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*
-
-# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
-- k8s.controllermanager.nodeCollectorEvictionsDelta
-- k8s.apiserver.currentInflightRequestsReadOnly
-- k8s.apiserver.currentInflightRequestsMutating
-- k8s.scheduler.schedulerPendingPodsActive
-- k8s.scheduler.schedulerPendingPodsBackoff
-- k8s.scheduler.schedulerPendingPodsUnschedulable
-- k8s.apiserver.storageObjects_*

--- a/e2e/1_25-exceptions.yml
+++ b/e2e/1_25-exceptions.yml
@@ -2,3 +2,7 @@
 except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*
+
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating

--- a/e2e/1_26-exceptions.yml
+++ b/e2e/1_26-exceptions.yml
@@ -3,11 +3,3 @@ except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*
 
-# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
-- k8s.controllermanager.nodeCollectorEvictionsDelta
-- k8s.apiserver.currentInflightRequestsReadOnly
-- k8s.apiserver.currentInflightRequestsMutating
-- k8s.scheduler.schedulerPendingPodsActive
-- k8s.scheduler.schedulerPendingPodsBackoff
-- k8s.scheduler.schedulerPendingPodsUnschedulable
-- k8s.apiserver.storageObjects_*

--- a/e2e/1_26-exceptions.yml
+++ b/e2e/1_26-exceptions.yml
@@ -3,3 +3,6 @@ except_metrics:
 # removed from 1.23
 - k8s.apiserver.etcd.objectCount_*
 
+# This metrics are pending to be transformed as DM, once they are we can remove this exceptions
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating


### PR DESCRIPTION
I can't find the specific PR that these were added in, but generally the E2E exception files are used so that E2E testing will pass for `nri-kubernetes` agent changes before the backend changes that transform these metrics to dimensional metrics have landed. These metrics have now been transformed (as seen in the `e2e/k8s.yml` file), so they can now be removed from the exception file. 