### PR TITLE
Update deprecated GitHub set-state action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,15 +78,15 @@ jobs:
           MINOR=$(echo "${{ matrix.k8sVersion }}"|sed -e 's_v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_\2_')
 
           if [ "$MINOR" -le 22 ]; then
-            echo "{exceptions}={1_22}" >> $GITHUB_OUTPUT
+            echo "exceptions=1_22" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 23 ]; then
-            echo "{exceptions}={1_23}" >> $GITHUB_OUTPUT
+            echo "exceptions=1_23" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 24 ]; then
-            echo "{exceptions}={1_24}" >> $GITHUB_OUTPUT
+            echo "exceptions=1_24" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 25 ]; then
-            echo "{exceptions}={1_25}" >> $GITHUB_OUTPUT
+            echo "exceptions=1_25" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -ge 26 ]; then
-            echo "{exceptions}={1_26}" >> $GITHUB_OUTPUT
+            echo "exceptions=1_26" >> $GITHUB_OUTPUT
           fi
       - name: Run e2e-test
         uses: newrelic/newrelic-integration-e2e-action@v1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,15 +78,15 @@ jobs:
           MINOR=$(echo "${{ matrix.k8sVersion }}"|sed -e 's_v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_\2_')
 
           if [ "$MINOR" -le 22 ]; then
-            echo "::set-output name=exceptions::1_22"
+            echo "{exceptions}={1_22}" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 23 ]; then
-            echo "::set-output name=exceptions::1_23"
+            echo "{exceptions}={1_23}" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 24 ]; then
-            echo "::set-output name=exceptions::1_24"
+            echo "{exceptions}={1_24}" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 25 ]; then
-            echo "::set-output name=exceptions::1_25"
+            echo "{exceptions}={1_25}" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -ge 26 ]; then
-            echo "::set-output name=exceptions::1_26"
+            echo "{exceptions}={1_26}" >> $GITHUB_OUTPUT
           fi
       - name: Run e2e-test
         uses: newrelic/newrelic-integration-e2e-action@v1

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           changed=$(ct --config .github/ct.yaml list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "{changed}={true}" >> $GITHUB_OUTPUT
           fi
       - name: Run helm unit tests
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -59,7 +59,7 @@ jobs:
         run: |
           changed=$(ct --config .github/ct.yaml list-changed)
           if [[ -n "$changed" ]]; then
-            echo "{changed}={true}" >> $GITHUB_OUTPUT
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
       - name: Run helm unit tests
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
The `set-output` command is deprecated and will be fully disabled this May: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This will clean up a lot of warnings when these workflows run. 