### PR TITLE
Rerun Kubelet Scraper When Data is Populated

### DIFF
--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.12.0
+version: 3.12.1
 appVersion: 3.6.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 3.12.1
+version: 3.12.0
 appVersion: 3.6.0
 
 dependencies:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -118,6 +118,8 @@ kubelet:
     timeout: 10s
     # -- Number of retries after timeout expired
     retries: 3
+    # -- Max number of scraper rerun after scraper runtime error happens
+    scraperMaxReruns: 4
   # port:
   # scheme:
 

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -42,7 +42,6 @@ var (
 	integrationVersion = "0.0.0"
 	gitCommit          = ""
 	buildDate          = ""
-	kubeletReruns      = 0
 )
 
 var logger *log.Logger
@@ -193,11 +192,10 @@ func runScrapers(c *config.Config, ksmScraper *ksm.Scraper, kubeletScraper *kube
 	if c.Kubelet.Enabled {
 		err := kubeletScraper.Run(i)
 		if err != nil {
-			if kubeletScraper.IsMaxRerunReached(kubeletReruns) {
+			if kubeletScraper.IsMaxRerunReached() {
 				return fmt.Errorf("retrieving kubelet data: %w", err)
 			}
-			kubeletReruns++
-			logger.Debugf("the kubelet scraper fails due to %v, will rerun it for %dth time", err, kubeletReruns)
+			logger.Debugf("the kubelet scraper fails due to %v, will rerun it", err)
 		}
 	}
 

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -196,6 +196,7 @@ func runScrapers(c *config.Config, ksmScraper *ksm.Scraper, kubeletScraper *kube
 				return fmt.Errorf("retrieving kubelet data: %w", err)
 			}
 			logger.Debugf("the kubelet scraper fails due to %v, will rerun it", err)
+			kubeletScraper.IncCurrentReruns()
 		}
 	}
 

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -195,10 +195,9 @@ func runScrapers(c *config.Config, ksmScraper *ksm.Scraper, kubeletScraper *kube
 		if err != nil {
 			if kubeletScraper.IsMaxRerunReached(kubeletReruns) {
 				return fmt.Errorf("retrieving kubelet data: %w", err)
-			} else {
-				kubeletReruns++
-				logger.Debug("the kubelet scraper fails due to %v, will rerun it for %dth time", err, kubeletReruns)
 			}
+			kubeletReruns++
+			logger.Debug("the kubelet scraper fails due to %v, will rerun it for %dth time", err, kubeletReruns)
 		}
 	}
 

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -197,7 +197,7 @@ func runScrapers(c *config.Config, ksmScraper *ksm.Scraper, kubeletScraper *kube
 				return fmt.Errorf("retrieving kubelet data: %w", err)
 			}
 			kubeletReruns++
-			logger.Debug("the kubelet scraper fails due to %v, will rerun it for %dth time", err, kubeletReruns)
+			logger.Debugf("the kubelet scraper fails due to %v, will rerun it for %dth time", err, kubeletReruns)
 		}
 	}
 

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -42,6 +42,7 @@ var (
 	integrationVersion = "0.0.0"
 	gitCommit          = ""
 	buildDate          = ""
+	kubeletReruns      = 0
 )
 
 var logger *log.Logger
@@ -192,7 +193,12 @@ func runScrapers(c *config.Config, ksmScraper *ksm.Scraper, kubeletScraper *kube
 	if c.Kubelet.Enabled {
 		err := kubeletScraper.Run(i)
 		if err != nil {
-			return fmt.Errorf("retrieving kubelet data: %w", err)
+			if kubeletScraper.IsMaxRerunReached(kubeletReruns) {
+				return fmt.Errorf("retrieving kubelet data: %w", err)
+			} else {
+				kubeletReruns++
+				logger.Debug("the kubelet scraper fails due to %v, will rerun it for %dth time", err, kubeletReruns)
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,9 @@ type Kubelet struct {
 	Timeout time.Duration `mapstructure:"timeout"`
 	// Retries controls how many times the integration will attempt to connect to the kubelet before giving up.
 	Retries int `mapstructure:"retries"`
+	// ScraperMaxReruns controls how many times the integration will attempt to
+	// run kubelet scraper when runtime error happens before giving up.
+	ScraperMaxReruns int `mapstructure:"scraperMaxReruns"`
 }
 
 // ControlPlane contains config options for the control plane scraper.

--- a/src/kubelet/scraper.go
+++ b/src/kubelet/scraper.go
@@ -141,7 +141,12 @@ func (s *Scraper) Close() {
 	}
 }
 
-// Check whether the max number of scraper reruns has been reached or not.
+// Increase the kubelet currentReruns counter.
+func (s *Scraper) IncCurrentReruns() {
+	s.currentReruns++
+}
+
+// Check whether the max number of kubulet scraper reruns has been reached or not.
 func (s *Scraper) IsMaxRerunReached() bool {
 	return s.currentReruns > s.config.ScraperMaxReruns
 }

--- a/src/kubelet/scraper.go
+++ b/src/kubelet/scraper.go
@@ -39,6 +39,7 @@ type Scraper struct {
 	defaultNetworkInterface string
 	nodeGetter              listersv1.NodeLister
 	informerClosers         []chan<- struct{}
+	currentReruns           int
 	Filterer                discovery.NamespaceFilterer
 }
 
@@ -50,9 +51,10 @@ type ScraperOpt func(s *Scraper) error
 func NewScraper(config *config.Config, providers Providers, options ...ScraperOpt) (*Scraper, error) {
 	var err error
 	s := &Scraper{
-		config:    config,
-		Providers: providers,
-		logger:    logutil.Discard,
+		config:        config,
+		Providers:     providers,
+		logger:        logutil.Discard,
+		currentReruns: 0,
 	}
 
 	// TODO: Sanity check config
@@ -140,6 +142,6 @@ func (s *Scraper) Close() {
 }
 
 // Check whether the max number of scraper reruns has been reached or not.
-func (s *Scraper) IsMaxRerunReached(curReruns int) bool {
-	return curReruns > s.config.ScraperMaxReruns
+func (s *Scraper) IsMaxRerunReached() bool {
+	return s.currentReruns > s.config.ScraperMaxReruns
 }

--- a/src/kubelet/scraper.go
+++ b/src/kubelet/scraper.go
@@ -139,7 +139,7 @@ func (s *Scraper) Close() {
 	}
 }
 
-// Run scraper collect the data populating the integration entities
+// Check whether the max number of scraper reruns has been reached or not.
 func (s *Scraper) IsMaxRerunReached(curReruns int) bool {
 	return curReruns > s.config.ScraperMaxReruns
 }

--- a/src/kubelet/scraper.go
+++ b/src/kubelet/scraper.go
@@ -138,3 +138,8 @@ func (s *Scraper) Close() {
 		close(ch)
 	}
 }
+
+// Run scraper collect the data populating the integration entities
+func (s *Scraper) IsMaxRerunReached(curReruns int) bool {
+	return curReruns > s.config.ScraperMaxReruns
+}


### PR DESCRIPTION
This PR addresses the issue when Kubelet becomes temporarily unavailable, no Kubelet metrics are populated, and the error "kubelet data was not populated after trying all endpoints" from Kubelet scraper is returned to main.  
The current behavior of K8s agent main is that if any (ksm, kubelet, controlplane) scrapers returns any error, the K8s agent will Immediately fail and exit with code 5.

Instead of exiting immediately when kubelet is not reachable, we can set a ScraperMaxReruns (e.g., 4 times) at the scraper level. This will improve customer experience when kubelet is temporarily not reachable.