### PR TITLE
Add failed job to testing resources.

### DIFF
--- a/charts/internal/e2e-resources/Chart.yaml
+++ b/charts/internal/e2e-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.4.0-devel
+version: 1.5.0-devel
 description: This chart creates e2e resources for nri-kubernetes.
 name: e2e-resources
 

--- a/charts/internal/e2e-resources/README.md
+++ b/charts/internal/e2e-resources/README.md
@@ -1,6 +1,6 @@
 # e2e-resources
 
-![Version: 1.4.0-devel](https://img.shields.io/badge/Version-1.4.0--devel-informational?style=flat-square)
+![Version: 1.5.0-devel](https://img.shields.io/badge/Version-1.5.0--devel-informational?style=flat-square)
 
 This chart creates e2e resources for nri-kubernetes.
 
@@ -30,6 +30,7 @@ This chart creates e2e resources for nri-kubernetes.
 | cronjob.enabled | bool | `true` |  |
 | daemonSet.enabled | bool | `true` |  |
 | deployment.enabled | bool | `true` |  |
+| failingJob.enabled | bool | `true` |  |
 | hpa.enabled | bool | `true` |  |
 | loadBalancerService.annotations | object | `{}` |  |
 | loadBalancerService.enabled | bool | `true` |  |

--- a/charts/internal/e2e-resources/templates/cronjob.yml
+++ b/charts/internal/e2e-resources/templates/cronjob.yml
@@ -12,6 +12,7 @@ spec:
   startingDeadlineSeconds: 200
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 200
       template:
         spec:
           containers:

--- a/charts/internal/e2e-resources/templates/job-fails.yaml
+++ b/charts/internal/e2e-resources/templates/job-fails.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.failingJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-failjob
+spec:
+  activeDeadlineSeconds: 200
+  completions: 4
+  parallelism: 2
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: main
+        image: docker.io/library/bash:5
+        command: ["bash"]
+        args:
+        - -c
+        - echo "Hello world! I'm going to exit with 42 to simulate a software bug." && sleep 5 && exit 42
+  backoffLimit: 6
+{{- end }}

--- a/charts/internal/e2e-resources/values.yaml
+++ b/charts/internal/e2e-resources/values.yaml
@@ -6,6 +6,10 @@ pending:
 cronjob:
   enabled: true
 
+# Deploy a failing job
+failingJob:
+  enabled: true
+
 # Deploy a dummy daemonSet
 daemonSet:
   enabled: true


### PR DESCRIPTION
The Kubernetes team is working on adding new metrics for all Kubernetes workloads, including `Job`. This PR adds a failing `Job` workload that will be used in the local dev environment.

### Testing Plan
- Run local dev environment: make local-env-start
- Observe failed jobs