### PR TITLE
Enable PV and PVC by default in testing resources.

### DIFF
--- a/charts/internal/e2e-resources/Chart.yaml
+++ b/charts/internal/e2e-resources/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.5.0-devel
+version: 1.6.0-devel
 description: This chart creates e2e resources for nri-kubernetes.
 name: e2e-resources
 

--- a/charts/internal/e2e-resources/README.md
+++ b/charts/internal/e2e-resources/README.md
@@ -1,6 +1,6 @@
 # e2e-resources
 
-![Version: 1.5.0-devel](https://img.shields.io/badge/Version-1.5.0--devel-informational?style=flat-square)
+![Version: 1.6.0-devel](https://img.shields.io/badge/Version-1.6.0--devel-informational?style=flat-square)
 
 This chart creates e2e resources for nri-kubernetes.
 
@@ -36,8 +36,8 @@ This chart creates e2e resources for nri-kubernetes.
 | loadBalancerService.enabled | bool | `true` |  |
 | loadBalancerService.fakeIP | string | `""` |  |
 | pending.enabled | bool | `true` |  |
-| persistentVolume.enabled | bool | `false` |  |
-| persistentVolumeClaim.enabled | bool | `false` |  |
+| persistentVolume.enabled | bool | `true` |  |
+| persistentVolumeClaim.enabled | bool | `true` |  |
 | persistentVolumeClaim.storageClassName | string | `"standard"` |  |
 | scraper.enabled | bool | `false` |  |
 | statefulSet.enabled | bool | `true` |  |

--- a/charts/internal/e2e-resources/values.yaml
+++ b/charts/internal/e2e-resources/values.yaml
@@ -28,9 +28,9 @@ hpa:
 
 # Create PVs and PVCs
 persistentVolume:
-  enabled: false
+  enabled: true
 persistentVolumeClaim:
-  enabled: false
+  enabled: true
   storageClassName: "standard"  # Default for minikube
 
 # Deploy a loadBalancer service


### PR DESCRIPTION
The Kubernetes team is working on adding new metrics for all Kubernetes workloads, including `PesisitentVolumeClaim` and `PersistentVolume`. This PR adds a enables both workloads by default for the local dev environment and E2E testing. 

### Testing Plan
- Run local dev environment: make local-env-start
- Observe that `PV` and `PVC` workloads exist