### PR TITLE
Add KSM metrics promoted to stable category

### DIFF
--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -3323,6 +3323,14 @@ entities:
           legacyEventType: K8sDaemonsetSample
           legacyNames:
             - createdAt
+      - name: k8s.daemonset.observedGeneration
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sDaemonsetSample
+          legacyNames:
+            - observedGeneration
       - name: k8s.daemonset.metadataGeneration
         type: gauge
         defaultResolution: 15
@@ -4193,6 +4201,14 @@ entities:
           legacyEventType: K8sDeploymentSample
           legacyNames:
             - podsTotal
+      - name: k8s.deployment.podsReady
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sDeploymentSample
+          legacyNames:
+            - podsReady
       - name: k8s.deployment.podsUnavailable
         type: gauge
         defaultResolution: 15
@@ -4209,6 +4225,38 @@ entities:
           legacyEventType: K8sDeploymentSample
           legacyNames:
             - podsUpdated
+      - name: k8s.deployment.observedGeneration
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sDeploymentSample
+          legacyNames:
+            - observedGeneration
+      - name: k8s.deployment.isPaused
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sDeploymentSample
+          legacyNames:
+            - isPaused
+      - name: k8s.deployment.rollingUpdateMaxPodsSurge
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sDeploymentSample
+          legacyNames:
+            - rollingUpdateMaxPodsSurge
+      - name: k8s.deployment.metadataGeneration
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sDeploymentSample
+          legacyNames:
+            - metadataGeneration
       - name: k8s.deployment.podsMissing
         type: gauge
         defaultResolution: 15
@@ -4238,6 +4286,20 @@ entities:
           legacyNames:
             - namespaceName
             - namespace
+          legacyEventTypes:
+            - K8sDeploymentSample
+      - name: k8s.deployment.isAvailable
+        type: string
+        migrationInformation:
+          legacyNames:
+            - isAvailable
+          legacyEventTypes:
+            - K8sDeploymentSample
+      - name: k8s.deployment.isProgressing
+        type: string
+        migrationInformation:
+          legacyNames:
+            - isProgressing
           legacyEventTypes:
             - K8sDeploymentSample
       - name: entity.guid
@@ -10044,6 +10106,14 @@ entities:
           legacyEventType: K8sReplicasetSample
           legacyNames:
             - observedGeneration
+      - name: k8s.replicaset.metadataGeneration
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sReplicasetSample
+          legacyNames:
+            - metadataGeneration
       - name: k8s.replicaset.podsDesired
         type: gauge
         defaultResolution: 15
@@ -10097,6 +10167,27 @@ entities:
         migrationInformation:
           legacyNames:
             - deploymentName
+          legacyEventTypes:
+            - K8sReplicasetSample
+      - name: k8s.replicaset.ownerName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - ownerName
+          legacyEventTypes:
+            - K8sReplicasetSample
+      - name: k8s.replicaset.ownerKind
+        type: string
+        migrationInformation:
+          legacyNames:
+            - ownerKind
+          legacyEventTypes:
+            - K8sReplicasetSample
+      - name: k8s.replicaset.ownerIsController
+        type: string
+        migrationInformation:
+          legacyNames:
+            - ownerIsController
           legacyEventTypes:
             - K8sReplicasetSample
       - name: k8s.namespaceName

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -853,31 +853,6 @@ var KSMSpecs = definition.SpecGroups{
 				ValueFunc: prometheus.FromValue("kube_endpoint_address_available"),
 				Type:      sdkMetric.GAUGE,
 			},
-			{
-				Name:      "ipAddress",
-				ValueFunc: prometheus.FromLabelValue("kube_endpoint_address", "ip"),
-				Type:      sdkMetric.ATTRIBUTE,
-			},
-			{
-				Name:      "ipAddressReady",
-				ValueFunc: prometheus.FromLabelValue("kube_endpoint_address", "ready"),
-				Type:      sdkMetric.ATTRIBUTE,
-			},
-			{
-				Name:      "portName",
-				ValueFunc: prometheus.FromLabelValue("kube_endpoint_ports", "port_name"),
-				Type:      sdkMetric.ATTRIBUTE,
-			},
-			{
-				Name:      "portProtocol",
-				ValueFunc: prometheus.FromLabelValue("kube_endpoint_ports", "port_protocol"),
-				Type:      sdkMetric.ATTRIBUTE,
-			},
-			{
-				Name:      "portNumber",
-				ValueFunc: prometheus.FromLabelValue("kube_endpoint_ports", "port_number"),
-				Type:      sdkMetric.ATTRIBUTE,
-			},
 		},
 	},
 	// We get Pod metrics from kube-state-metrics for those pods that are in
@@ -1112,8 +1087,6 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_endpoint_labels"},
 	{MetricName: "kube_endpoint_address_not_ready"},
 	{MetricName: "kube_endpoint_address_available"},
-	{MetricName: "kube_endpoint_ports"},
-	{MetricName: "kube_endpoint_address"},
 	// hpa
 	{MetricName: "kube_horizontalpodautoscaler_labels"},
 	{MetricName: "kube_horizontalpodautoscaler_metadata_generation"},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -644,11 +644,16 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "podsTotal", ValueFunc: prometheus.FromValue("kube_replicaset_status_replicas"), Type: sdkMetric.GAUGE},
 			{Name: "podsFullyLabeled", ValueFunc: prometheus.FromValue("kube_replicaset_status_fully_labeled_replicas"), Type: sdkMetric.GAUGE},
 			{Name: "observedGeneration", ValueFunc: prometheus.FromValue("kube_replicaset_status_observed_generation"), Type: sdkMetric.GAUGE},
+			{Name: "metadataGeneration", ValueFunc: prometheus.FromValue("kube_replicaset_metadata_generation"), Type: sdkMetric.GAUGE},
 			{Name: "replicasetName", ValueFunc: prometheus.FromLabelValue("kube_replicaset_created", "replicaset"), Type: sdkMetric.ATTRIBUTE},
 			// namespace is here for backwards compatibility, we should use the namespaceName
 			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_replicaset_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_replicaset_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "deploymentName", ValueFunc: ksmMetric.GetDeploymentNameForReplicaSet(), Type: sdkMetric.ATTRIBUTE},
+			{Name: "label.*", ValueFunc: prometheus.InheritAllLabelsFrom("replicaset", "kube_replicaset_labels"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "ownerName", ValueFunc: prometheus.FromLabelValue("kube_replicaset_owner", "owner_name"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "ownerKind", ValueFunc: prometheus.FromLabelValue("kube_replicaset_owner", "owner_kind"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "ownerIsController", ValueFunc: prometheus.FromLabelValue("kube_replicaset_owner", "owner_is_controller"), Type: sdkMetric.ATTRIBUTE},
 			// computed
 			{
 				Name: "podsMissing", ValueFunc: Subtract(
@@ -698,6 +703,7 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "podsUnavailable", ValueFunc: prometheus.FromValue("kube_daemonset_status_number_unavailable"), Type: sdkMetric.GAUGE},
 			{Name: "podsMisscheduled", ValueFunc: prometheus.FromValue("kube_daemonset_status_number_misscheduled"), Type: sdkMetric.GAUGE},
 			{Name: "podsUpdatedScheduled", ValueFunc: prometheus.FromValue("kube_daemonset_status_updated_number_scheduled"), Type: sdkMetric.GAUGE},
+			{Name: "observedGeneration", ValueFunc: prometheus.FromValue("kube_daemonset_status_observed_generation"), Type: sdkMetric.GAUGE},
 			{Name: "metadataGeneration", ValueFunc: prometheus.FromValue("kube_daemonset_metadata_generation"), Type: sdkMetric.GAUGE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_daemonset_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "daemonsetName", ValueFunc: prometheus.FromLabelValue("kube_daemonset_created", "daemonset"), Type: sdkMetric.ATTRIBUTE},
@@ -730,9 +736,16 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "createdAt", ValueFunc: prometheus.FromValue("kube_deployment_created"), Type: sdkMetric.GAUGE},
 			{Name: "podsDesired", ValueFunc: prometheus.FromValue("kube_deployment_spec_replicas"), Type: sdkMetric.GAUGE},
 			{Name: "podsTotal", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas"), Type: sdkMetric.GAUGE},
+			{Name: "podsReady", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_ready"), Type: sdkMetric.GAUGE},
 			{Name: "podsAvailable", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_available"), Type: sdkMetric.GAUGE},
 			{Name: "podsUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_unavailable"), Type: sdkMetric.GAUGE},
 			{Name: "podsUpdated", ValueFunc: prometheus.FromValue("kube_deployment_status_replicas_updated"), Type: sdkMetric.GAUGE},
+			{Name: "observedGeneration", ValueFunc: prometheus.FromValue("kube_deployment_status_observed_generation"), Type: sdkMetric.GAUGE},
+			{Name: "isPaused", ValueFunc: prometheus.FromValue("kube_deployment_spec_paused"), Type: sdkMetric.GAUGE},
+			{Name: "rollingUpdateMaxPodsSurge", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_surge"), Type: sdkMetric.GAUGE},
+			{Name: "metadataGeneration", ValueFunc: prometheus.FromValue("kube_deployment_metadata_generation"), Type: sdkMetric.GAUGE},
+			{Name: "isAvailable", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_available", "status"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "isProgressing", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_progressing", "status"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "podsMaxUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_unavailable"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
@@ -839,6 +852,31 @@ var KSMSpecs = definition.SpecGroups{
 				Name:      "addressAvailable",
 				ValueFunc: prometheus.FromValue("kube_endpoint_address_available"),
 				Type:      sdkMetric.GAUGE,
+			},
+			{
+				Name:      "ipAddress",
+				ValueFunc: prometheus.FromLabelValue("kube_endpoint_address", "ip"),
+				Type:      sdkMetric.ATTRIBUTE,
+			},
+			{
+				Name:      "ipAddressReady",
+				ValueFunc: prometheus.FromLabelValue("kube_endpoint_address", "ready"),
+				Type:      sdkMetric.ATTRIBUTE,
+			},
+			{
+				Name:      "portName",
+				ValueFunc: prometheus.FromLabelValue("kube_endpoint_ports", "port_name"),
+				Type:      sdkMetric.ATTRIBUTE,
+			},
+			{
+				Name:      "portProtocol",
+				ValueFunc: prometheus.FromLabelValue("kube_endpoint_ports", "port_protocol"),
+				Type:      sdkMetric.ATTRIBUTE,
+			},
+			{
+				Name:      "portNumber",
+				ValueFunc: prometheus.FromLabelValue("kube_endpoint_ports", "port_number"),
+				Type:      sdkMetric.ATTRIBUTE,
 			},
 		},
 	},
@@ -990,6 +1028,7 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_daemonset_status_number_unavailable"},
 	{MetricName: "kube_daemonset_status_number_misscheduled"},
 	{MetricName: "kube_daemonset_status_updated_number_scheduled"},
+	{MetricName: "kube_daemonset_status_observed_generation"},
 	{MetricName: "kube_daemonset_metadata_generation"},
 	{MetricName: "kube_daemonset_labels", Value: prometheus.QueryValue{
 		Value: prometheus.GaugeValue(1),
@@ -999,7 +1038,12 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_replicaset_status_replicas"},
 	{MetricName: "kube_replicaset_status_fully_labeled_replicas"},
 	{MetricName: "kube_replicaset_status_observed_generation"},
+	{MetricName: "kube_replicaset_metadata_generation"},
 	{MetricName: "kube_replicaset_created"},
+	{MetricName: "kube_replicaset_labels", Value: prometheus.QueryValue{
+		Value: prometheus.GaugeValue(1),
+	}},
+	{MetricName: "kube_replicaset_owner"},
 	{MetricName: "kube_namespace_labels", Value: prometheus.QueryValue{
 		Value: prometheus.GaugeValue(1),
 	}},
@@ -1013,9 +1057,34 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_deployment_created"},
 	{MetricName: "kube_deployment_spec_replicas"},
 	{MetricName: "kube_deployment_status_replicas"},
+	{MetricName: "kube_deployment_status_replicas_ready"},
 	{MetricName: "kube_deployment_status_replicas_available"},
 	{MetricName: "kube_deployment_status_replicas_unavailable"},
 	{MetricName: "kube_deployment_status_replicas_updated"},
+	{MetricName: "kube_deployment_status_observed_generation"},
+	{MetricName: "kube_deployment_spec_paused"},
+	{MetricName: "kube_deployment_spec_strategy_rollingupdate_max_surge"},
+	{MetricName: "kube_deployment_metadata_generation"},
+	{
+		MetricName: "kube_deployment_status_condition",
+		CustomName: "kube_deployment_status_condition_available",
+		Labels: prometheus.QueryLabels{
+			Labels: prometheus.Labels{"condition": "Available"},
+		},
+		Value: prometheus.QueryValue{
+			Value: prometheus.GaugeValue(1),
+		},
+	},
+	{
+		MetricName: "kube_deployment_status_condition",
+		CustomName: "kube_deployment_status_condition_progressing",
+		Labels: prometheus.QueryLabels{
+			Labels: prometheus.Labels{"condition": "Progressing"},
+		},
+		Value: prometheus.QueryValue{
+			Value: prometheus.GaugeValue(1),
+		},
+	},
 	{MetricName: "kube_deployment_spec_strategy_rollingupdate_max_unavailable"},
 	{MetricName: "kube_pod_status_phase", Labels: prometheus.QueryLabels{
 		Labels: prometheus.Labels{"phase": "Pending"},
@@ -1043,6 +1112,8 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_endpoint_labels"},
 	{MetricName: "kube_endpoint_address_not_ready"},
 	{MetricName: "kube_endpoint_address_available"},
+	{MetricName: "kube_endpoint_ports"},
+	{MetricName: "kube_endpoint_address"},
 	// hpa
 	{MetricName: "kube_horizontalpodautoscaler_labels"},
 	{MetricName: "kube_horizontalpodautoscaler_metadata_generation"},


### PR DESCRIPTION
# Description
The Kubernetes team is updating metrics for all supported workloads and services. Specifically, [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) has upgraded several metrics and services from `experimental` to `stable`.

# PR Changes
This PR makes changes to the agent to start scraping the following metrics:

For [Enpoint](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/endpoint-metrics.md#endpoint-metrics) services:
`kube_endpoint_info`

For [DaemonSet](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/daemonset-metrics.md#daemonset-metrics) workloads:
`kube_daemonset_status_observed_generation`

For [Deployment](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/deployment-metrics.md#deployment-metrics) workloads:
`kube_deployment_status_replicas_ready`
`kube_deployment_status_observed_generation`
`kube_deployment_status_condition`
`kube_deployment_spec_paused`
`kube_deployment_spec_strategy_rollingupdate_max_surge`
`kube_deployment_metadata_generation`

For [ReplicaSet](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/replicaset-metrics.md#replicaset-metrics) workloads:
`kube_replicaset_metadata_generation`
`kube_replicaset_labels`
`kube_replicaset_owner`

# Related PRs
[infra-integration-specs #310](https://source.datanerd.us/infrastructure/infra-integration-specs/pull/310)
[infra-metrics-utils #84](https://source.datanerd.us/infrastructure/infra-metrics-utils/pull/84)
[dirac #7971](https://source.datanerd.us/dirac/dirac/pull/7971)

# Testing Plan
- [x] Run local testing environment and check metrics are ingested to NR1 in the respective `K8s*Sample` tables