### PR TITLE
Bump helm/chart-releaser-action from 1.3.0 to 1.5.0

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -39,6 +39,6 @@ jobs:
         run: helm repo add newrelic https://helm-charts.newrelic.com
 
       - name: Release workload charts
-        uses: helm/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Skipping E2E testing since this change only affects the github workflows. 

This change will get tested when we release a chart later today / early tomorrow am. 