### PR TITLE
Improvements on `datagen.sh`

### DIFF
--- a/charts/internal/e2e-resources/templates/cronjob.yml
+++ b/charts/internal/e2e-resources/templates/cronjob.yml
@@ -14,6 +14,9 @@ spec:
     spec:
       activeDeadlineSeconds: 200
       template:
+        metadata:
+          labels:
+            app: cronjob
         spec:
           containers:
           - name: busybox

--- a/charts/internal/e2e-resources/templates/job-fails.yaml
+++ b/charts/internal/e2e-resources/templates/job-fails.yaml
@@ -8,6 +8,9 @@ spec:
   completions: 4
   parallelism: 2
   template:
+    metadata:
+      labels:
+        app: failjob
     spec:
       restartPolicy: Never
       containers:

--- a/internal/testutil/datagen/README.md
+++ b/internal/testutil/datagen/README.md
@@ -17,8 +17,9 @@ More specifically, it will deploy:
   - Dummy Pods, Services, StatefulSets, DaemonSets and Deployments in several states
   - HPA targets
   - If enabled, PersistentVolumes and PersistentVolumeClaims
+  - Cronjob and Job
 
-After this, it will deploy KSM and programmatically hit all the endpoints required for the integration to work, and store them in a directory specified by the user:
+After this, it will deploy KSM and programmatically hit all the endpoints required for the integration to work, and store them in a directory named after the Kubernetes version used in the cluster.
 
 - Kubelet endpoints
   - `/pods`
@@ -36,14 +37,11 @@ It will do this by spawning a privileged, `hostNetwork` `alpine:latest` pod (the
 ## Usage
 
 ```
-./datagen.sh <output_folder>
+./datagen.sh
 ```
 
-Output folder would typically be a version number, e.g.
-
-```shell
-./datagen.sh 1_22
-```
+### `kube-state-metrics` version
+The script chooses the image version to use for KSM according to the Kubernetes version used by the cluster. If new Kubernetes versions need to be supported, the script will print out an error message alerting about the missing mapping.
 
 ### Arguments and config
 


### PR DESCRIPTION
# Description
`datagen.sh` is a tool to scrape static test data from a live cluster, and this data can then be used for integration tests. While useful, the tool is difficult to use and prone to error.

# PR Changes
This PR addresses several of the shortcomings of the tool to make it easier to use for developers:
1. Automates the mapping of the cluster's Kubernetes version to the correct KSM version to use
2. Waits for new entities (job, cronjob) to settle before scraping test data
3. Avoids common human errors by automating the process
4. Makes workflow more resilient by testing for resource availability before starting the scrape process

# Related PRs
None, this is a standalone PR.

# Testing Plan
- [x] Generate static test data for multiple Kubernetes versions and guarantee workflow works as intended