### PR TITLE
Add Default Scraper Max Rerun

### DIFF
--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -166,6 +166,7 @@ integrations that you have configured.
 | kubelet.extraVolumeMounts | list | `[]` | Defines where to mount volumes specified with `extraVolumes` |
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
 | kubelet.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable  |
+| kubelet.scraperMaxReruns | int | 4 | Max number of kubelet scraper reruns when scraper runtime error happens. |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -160,13 +160,13 @@ integrations that you have configured.
 | kubelet.agentConfig | object | `{}` | Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster. It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in [New Relic docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/) e.g. you can set `passthrough_environment` int the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file) so the agent let use that environment variables to the integrations. |
 | kubelet.config.retries | int | `3` | Number of retries after timeout expired |
 | kubelet.config.timeout | string | `"10s"` | Timeout for the kubelet APIs contacted by the integration |
+| kubelet.config.scraperMaxReruns | int | 4 | Max number of kubelet scraper reruns when scraper runtime error happens. |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
 | kubelet.extraEnv | list | `[]` | Add user environment variables to the agent |
 | kubelet.extraEnvFrom | list | `[]` | Add user environment from configMaps or secrets as variables to the agent |
 | kubelet.extraVolumeMounts | list | `[]` | Defines where to mount volumes specified with `extraVolumes` |
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
 | kubelet.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable  |
-| kubelet.scraperMaxReruns | int | 4 | Max number of kubelet scraper reruns when scraper runtime error happens. |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -159,8 +159,8 @@ integrations that you have configured.
 | kubelet | object | See `values.yaml` | Configuration for the DaemonSet that collects metrics from the Kubelet. |
 | kubelet.agentConfig | object | `{}` | Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster. It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in [New Relic docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/) e.g. you can set `passthrough_environment` int the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file) so the agent let use that environment variables to the integrations. |
 | kubelet.config.retries | int | `3` | Number of retries after timeout expired |
-| kubelet.config.timeout | string | `"10s"` | Timeout for the kubelet APIs contacted by the integration |
 | kubelet.config.scraperMaxReruns | int | 4 | Max number of kubelet scraper reruns when scraper runtime error happens. |
+| kubelet.config.timeout | string | `"10s"` | Timeout for the kubelet APIs contacted by the integration |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
 | kubelet.extraEnv | list | `[]` | Add user environment variables to the agent |
 | kubelet.extraEnvFrom | list | `[]` | Add user environment from configMaps or secrets as variables to the agent |

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -113,13 +113,13 @@ kubelet:
     requests:
       cpu: 100m
       memory: 150M
+  # -- Max number of scraper rerun when scraper runtime error happens
+  scraperMaxReruns: 4
   config:
     # -- Timeout for the kubelet APIs contacted by the integration
     timeout: 10s
     # -- Number of retries after timeout expired
     retries: 3
-    # -- Max number of scraper rerun after scraper runtime error happens
-    scraperMaxReruns: 4
   # port:
   # scheme:
 

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -113,13 +113,13 @@ kubelet:
     requests:
       cpu: 100m
       memory: 150M
-  # -- Max number of scraper rerun when scraper runtime error happens
-  scraperMaxReruns: 4
   config:
     # -- Timeout for the kubelet APIs contacted by the integration
     timeout: 10s
     # -- Number of retries after timeout expired
     retries: 3
+    # -- Max number of scraper rerun when scraper runtime error happens
+    scraperMaxReruns: 4
   # port:
   # scheme:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,9 +13,10 @@ const (
 	DefaultConfigFileName   = "nri-kubernetes"
 	DefaultConfigFolderName = "/etc/newrelic-infra"
 
-	DefaultTimeout      = 10 * time.Second
-	DefaultRetries      = 3
-	DefaultAgentTimeout = 3 * time.Second
+	DefaultTimeout          = 10 * time.Second
+	DefaultRetries          = 3
+	DefaultScraperMaxReruns = 4
+	DefaultAgentTimeout     = 3 * time.Second
 
 	DefaultNetworkRouteFile = "/proc/net/route"
 
@@ -281,6 +282,7 @@ func LoadConfig(filePath string, fileName string) (*Config, error) {
 
 	v.SetDefault("kubelet|timeout", DefaultTimeout)
 	v.SetDefault("kubelet|retries", DefaultRetries)
+	v.SetDefault("kubelet|scraperMaxReruns", DefaultScraperMaxReruns)
 
 	v.SetDefault("controlPlane|timeout", DefaultTimeout)
 	v.SetDefault("controlPlane|retries", DefaultRetries)

--- a/src/kubelet/scraper.go
+++ b/src/kubelet/scraper.go
@@ -148,5 +148,5 @@ func (s *Scraper) IncCurrentReruns() {
 
 // Check whether the max number of kubulet scraper reruns has been reached or not.
 func (s *Scraper) IsMaxRerunReached() bool {
-	return s.currentReruns > s.config.ScraperMaxReruns
+	return s.currentReruns > s.config.Kubelet.ScraperMaxReruns
 }


### PR DESCRIPTION
# Description
Adjust the relative reference of ScraperMaxReruns in order to make it explicitly clearer. This change is related to https://github.com/newrelic/nri-kubernetes/pull/633

# Changes
- Change the way the parameter is referred in the code in order to make more explicit
- Add a default value in the config.go explicitly
- Change the default value of ScraperMaxReruns placement in the values.yaml
- Update readme

# Tests

In my values-local.yaml, I make the following changes
```
cluster: minikube
global:
  licenseKey: <my staging license key>
  nrStaging: true
kubelet:
  scraperMaxReruns: 4
```
 
The e2e tests succeeded means all the agents works as expected and can send data to NR backend.

Locally, I run `make local-env-start` and check the deployed agent status as follows

```
xqi@TFXCKKXMP9 nri-kubernetes % k get po | grep nr-nrk8s
nr-nrk8s-controlplane-qvlfg                        2/2     Running                0          2m34s
nr-nrk8s-ksm-ddb45fd78-hbrrt                       2/2     Running                0          2m34s
nr-nrk8s-kubelet-jmgsx                             2/2     Running                0          2m34s
xqi@TFXCKKXMP9 nri-kubernetes % k logs nr-nrk8s-kubelet-jmgsx       
Defaulted container "kubelet" out of: kubelet, agent
time="2023-03-14T19:23:20Z" level=info msg="Waiting for agent container to be ready..."
time="2023-03-14T19:23:40Z" level=info msg="New Relic Kubernetes integration Version: dev, Platform: linux/amd64, GoVersion: go1.20, GitCommit: bdc8cb52f3b6694d91e8c52c33d68015bf09bc2e, BuildDate: Tue Mar 14 12:23:02 PDT 2023\n"
time="2023-03-14T19:23:40Z" level=info msg="Trying to connect to kubelet locally with scheme=\"https\" hostURL=\"192.168.67.2:10250\""
time="2023-03-14T19:23:40Z" level=info msg="Connected to Kubelet through nodeIP with scheme=\"https\" hostURL=\"192.168.67.2:10250\""
xqi@TFXCKKXMP9 nri-kubernetes % k describe po nr-nrk8s-kubelet-jmgsx
Name:             nr-nrk8s-kubelet-jmgsx
Namespace:        default
Priority:         0
Service Account:  nr-newrelic-infrastructure
Node:             minikube/192.168.67.2
Start Time:       Tue, 14 Mar 2023 12:23:17 -0700
Labels:           app.kubernetes.io/component=kubelet
...
Annotations:      checksum/agent-config: 3c57d1534528615a326f66ac634a015aeac2bffc2f7382cc2560dee9af906e1f
...
Status:           Running
IP:               10.244.0.114
IPs:
  IP:           10.244.0.114
Controlled By:  DaemonSet/nr-nrk8s-kubelet
Containers:
  kubelet:
    Container ID:  docker://9673f431248aa099f17ee639023901a1a782d81e4bc0bf157b5266936dd4474c
    Image:         nri-kubernetes:tilt-35034f08c1545fee
    Image ID:      docker://sha256:35034f08c1545fee66c20f2092dcc7c2564f13c09b81d2462f2ffb46d36d752f
    Port:          <none>
    Host Port:     <none>
    Command:
      /tilt-restart-wrapper
      --watch_file=/tmp/.restart-proc
      /usr/local/bin/nri-kubernetes
    State:          Running
      Started:      Tue, 14 Mar 2023 12:23:19 -0700
    Ready:          True
    Restart Count:  0
    Limits:
      memory:  300M
    Requests:
      cpu:     100m
      memory:  150M
    Environment:
      NRI_KUBERNETES_SINK_HTTP_PORT:  8003
      NRI_KUBERNETES_CLUSTERNAME:     minikube
      NRI_KUBERNETES_VERBOSE:         false
      NRI_KUBERNETES_NODENAME:         (v1:spec.nodeName)
      NRI_KUBERNETES_NODEIP:           (v1:status.hostIP)
    Mounts:
      /etc/newrelic-infra/nri-kubernetes.yml from nri-kubernetes-config (rw,path="nri-kubernetes.yml")
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-b2h8j (ro)
  agent:
    Container ID:  docker://9d292a7d9594580d603721b13fd395f751c4128b3f1792cd6599e680bd2d5af5
    Image:         newrelic/infrastructure-bundle:2.8.38
    Image ID:      docker-pullable://newrelic/infrastructure-bundle@sha256:f9b5c9190cd130f15f1266fc008e06dc503d9b209f012625eac40c04ad0c28a9
    Port:          8003/TCP
    Host Port:     0/TCP
    Args:
      newrelic-infra
    State:          Running
      Started:      Tue, 14 Mar 2023 12:23:20 -0700
    Ready:          True
    Restart Count:  0
    Limits:
      memory:  300M
    Requests:
      cpu:     100m
      memory:  150M
    Environment:
      NRIA_LICENSE_KEY:              <set to the key 'licenseKey' in secret 'nr-newrelic-infrastructure-license'>  Optional: false
      NRIA_OVERRIDE_HOSTNAME_SHORT:   (v1:spec.nodeName)
      NRIA_OVERRIDE_HOSTNAME:         (v1:spec.nodeName)
      NRI_KUBERNETES_NODE_NAME:       (v1:spec.nodeName)
      CLUSTER_NAME:                  minikube
      NRIA_PASSTHROUGH_ENVIRONMENT:  CLUSTER_NAME
      NRIA_HOST:                      (v1:status.hostIP)
    Mounts:
      /dev from dev (rw)
      ...
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  dev:
    Type:          HostPath (bare host directory volume)
    Path:          /dev
    HostPathType:  
 ...
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 :NoSchedule op=Exists
                             :NoExecute op=Exists
                             node.kubernetes.io/disk-pressure:NoSchedule op=Exists
...
Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  2m52s  default-scheduler  Successfully assigned default/nr-nrk8s-kubelet-jmgsx to minikube
  Normal  Pulled     2m51s  kubelet            Container image "nri-kubernetes:tilt-35034f08c1545fee" already present on machine
  Normal  Created    2m51s  kubelet            Created container kubelet
  Normal  Started    2m51s  kubelet            Started container kubelet
  Normal  Pulled     2m51s  kubelet            Container image "newrelic/infrastructure-bundle:2.8.38" already present on machine
  Normal  Created    2m51s  kubelet            Created container agent
  Normal  Started    2m50s  kubelet            Started container agent
```
