### PR TITLE
Deploy e2e testing resources to a specific namespace

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -57,9 +57,7 @@ kind: Namespace
 metadata:
   name: nri-k8s-dev
 """
-k8s_yaml([
-    blob(ns_yaml_str)
-])
+k8s_yaml([blob(ns_yaml_str)])
 
 k8s_yaml(helm('./charts/newrelic-infrastructure', name='nr', namespace='nri-k8s-dev', values=['values-dev.yaml', 'values-local.yaml']))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -18,7 +18,7 @@ if live_reload:
 
   # Building daemon binary locally.
   local_resource(
-    '%s-binary' % project_name, 
+    '%s-binary' % project_name,
     'GOOS=linux make compile',
     deps=[
             "./src",
@@ -34,7 +34,7 @@ if live_reload:
   ''' % (binary_name, project_name)
 
   docker_build_with_restart(
-    ref=project_name, 
+    ref=project_name,
     context='./bin',
     dockerfile_contents=dockerfile,
     entrypoint=[
@@ -49,6 +49,6 @@ if live_reload:
 else:
   docker_build(project_name, '.')
 
-k8s_yaml(helm('./charts/newrelic-infrastructure', name='nr', values=['values-dev.yaml', 'values-local.yaml']))
+k8s_yaml(helm('./charts/newrelic-infrastructure', name='nr', namespace='nri-k8s-dev', values=['values-dev.yaml', 'values-local.yaml']))
 
-k8s_yaml(helm('./charts/internal/e2e-resources', name='e2e-resources'))
+k8s_yaml(helm('./charts/internal/e2e-resources', name='e2e-resources', namespace='nri-k8s-dev'))

--- a/Tiltfile
+++ b/Tiltfile
@@ -49,6 +49,18 @@ if live_reload:
 else:
   docker_build(project_name, '.')
 
+# ns_yaml_str is wrapped as Blob so that Tiltfile will treat it as DATA and not as a filepath
+ns_yaml_str = """
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nri-k8s-dev
+"""
+k8s_yaml([
+    blob(ns_yaml_str)
+])
+
 k8s_yaml(helm('./charts/newrelic-infrastructure', name='nr', namespace='nri-k8s-dev', values=['values-dev.yaml', 'values-local.yaml']))
 
 k8s_yaml(helm('./charts/internal/e2e-resources', name='e2e-resources', namespace='nri-k8s-dev'))

--- a/charts/internal/e2e-resources/templates/namespace.yaml
+++ b/charts/internal/e2e-resources/templates/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: nri-k8s-dev

--- a/charts/internal/e2e-resources/templates/namespace.yaml
+++ b/charts/internal/e2e-resources/templates/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nri-k8s-dev


### PR DESCRIPTION
## Summary

When running the local dev environment, the local testing resources get deployed to the `default` namespace. This makes cleaning up the cluster a bit difficult. 

## Changes

- Change the local dev environment to deploy the testing + agent resources to the `nri-k8s-dev` namespace. 

## Testing

- Spin up local dev environment (`make local-dev-env`) and check that the testing resources deploy to the `nri-k8s-dev` namespace and that the cluster shows up in the New Relic UI.