### PR TITLE
Tell chart releaser to skip existing charts

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -41,4 +41,5 @@ jobs:
       - name: Release workload charts
         uses: helm/chart-releaser-action@v1.5.0
         env:
+          CR_SKIP_EXISTING: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Changes

- In a previous PR, we disabled the Helm lint check which requires a version bump for any changes to chart details (https://github.com/newrelic/nri-kubernetes/pull/665)
- Since the Helm chart releaser triggers on every push to main, we need this flag to prevent the releaser from trying to overwrite an existing release and failing. 
