### PR TITLE
chore(deps): bump manusa/actions-setup-minikube from 2.4.3 to 2.7.2

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.1
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: v1.28.0
           kubernetes version: ${{ matrix.k8sVersion }}

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -74,7 +74,7 @@ jobs:
             fi
           done
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.7.2
         if: steps.list-changed.outputs.changed == 'true'
         with:
           minikube version: v1.20.0


### PR DESCRIPTION
Recreates https://github.com/newrelic/nri-kubernetes/pull/653 because dependabot PRs don't work with E2E testing. 
