### PR TITLE
chore(deps): bump docker/setup-qemu-action from 1 to 2

### DIFF
--- a/.github/workflows/nightlyAndMainImage.yml
+++ b/.github/workflows/nightlyAndMainImage.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ github.event.schedule }}
         run: echo "DOCKER_IMAGE_TAG=nightly" >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Download all artifacts from build job


### PR DESCRIPTION
Recreates https://github.com/newrelic/nri-kubernetes/pull/652 since dependabot PRs don't work with E2E testing. 
