### PR TITLE
chore(deps) bump newrelic/infrastructure-bundle from 2.8.38 to 3.1.3

### DIFF
--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -30,7 +30,7 @@ images:
   agent:
     registry: ""
     repository: newrelic/infrastructure-bundle
-    tag: 2.8.41
+    tag: 3.1.1
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Kubernetes integration.
   # @default -- See `values.yaml`

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -30,7 +30,7 @@ images:
   agent:
     registry: ""
     repository: newrelic/infrastructure-bundle
-    tag: 3.1.1
+    tag: 3.1.3
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Kubernetes integration.
   # @default -- See `values.yaml`

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -30,7 +30,7 @@ images:
   agent:
     registry: ""
     repository: newrelic/infrastructure-bundle
-    tag: 3.1.1
+    tag: 2.8.41
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Kubernetes integration.
   # @default -- See `values.yaml`

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -30,7 +30,7 @@ images:
   agent:
     registry: ""
     repository: newrelic/infrastructure-bundle
-    tag: 2.8.38
+    tag: 3.1.1
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Kubernetes integration.
   # @default -- See `values.yaml`


### PR DESCRIPTION
There's a new release out https://github.com/newrelic/infrastructure-bundle/releases/tag/3.1.1
