### PR TITLE
Remove dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,22 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
     ignore:
       - dependency-name: "k8s.io/*"
     labels:
       - dependencies
-      - ci/skip-e2e 
+      - ci/skip-e2e
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 2
-    labels: 
+    labels:
       - ci/skip-e2e
       - dependencies
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 2
-    labels: 
+    labels:
       - ci/skip-e2e
       - dependencies


### PR DESCRIPTION
Limiting dependabot just causes more work day over day.
A higher limit will help address all upgrades in a shorter
period of time.
