### PR TITLE
Update Kubernetes image registry

### DIFF
--- a/charts/internal/e2e-resources/templates/hpa.yaml
+++ b/charts/internal/e2e-resources/templates/hpa.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: php-apache
-          image: k8s.gcr.io/hpa-example
+          image: registry.k8s.io/hpa-example
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
k8s.gcr.io image registry will be redirected to registry.k8s.io on Monday March 20th.
All images available in k8s.gcr.io are available at registry.k8s.io.

See https://kubernetes.io/blog/2023/03/10/image-registry-redirect/
