### PR TITLE
Add CronJob and Job KSM metrics

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,7 +77,9 @@ jobs:
         run: |
           MINOR=$(echo "${{ matrix.k8sVersion }}"|sed -e 's_v\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)_\2_')
 
-          if [ "$MINOR" -le 22 ]; then
+          if [ "$MINOR" -eq 16 ]; then
+            echo "exceptions=1_16" >> $GITHUB_OUTPUT
+          elif [ "$MINOR" -le 22 ]; then
             echo "exceptions=1_22" >> $GITHUB_OUTPUT
           elif [ "$MINOR" -eq 23 ]; then
             echo "exceptions=1_23" >> $GITHUB_OUTPUT

--- a/e2e/1_16-exceptions.yml
+++ b/e2e/1_16-exceptions.yml
@@ -1,0 +1,20 @@
+# This metrics are not present from 1.16
+except_metrics:
+# Added from 1.23
+- k8s.apiserver.currentInflightRequestsReadOnly
+- k8s.apiserver.currentInflightRequestsMutating
+- k8s.scheduler.schedulerPendingPodsActive
+- k8s.scheduler.schedulerPendingPodsBackoff
+- k8s.scheduler.schedulerPendingPodsUnschedulable
+- k8s.apiserver.storageObjects_*
+# Added from 1.24
+- k8s.controllermanager.nodeCollectorEvictionsDelta
+- k8s.container.oomEventsDelta
+# For Kubernetes 1.16, kube-state-metric helm charts v4.7.0+ no longer report metrics for CronJob
+- k8s.cronjob.createdAt
+- k8s.cronjob.isActive
+- k8s.cronjob.nextScheduledTime
+- k8s.cronjob.lastScheduledTime
+- k8s.cronjob.isSuspended
+- k8s.cronjob.specStartingDeadlineSeconds
+- k8s.cronjob.metadataResourceVersion

--- a/e2e/1_16-exceptions.yml
+++ b/e2e/1_16-exceptions.yml
@@ -18,3 +18,4 @@ except_metrics:
 - k8s.cronjob.isSuspended
 - k8s.cronjob.specStartingDeadlineSeconds
 - k8s.cronjob.metadataResourceVersion
+- k8s.job.failedPods

--- a/e2e/1_22-exceptions.yml
+++ b/e2e/1_22-exceptions.yml
@@ -10,3 +10,4 @@ except_metrics:
 # Added from 1.24
 - k8s.controllermanager.nodeCollectorEvictionsDelta
 - k8s.container.oomEventsDelta
+- k8s.job.failedPods

--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -5755,6 +5755,810 @@ entities:
       - event_type
       - provider
       - networkTag.*
+  - entityType: K8sJob
+    metrics:
+      - name: k8s.job.createdAt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - createdAt
+      - name: k8s.job.startedAt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - startedAt
+      - name: k8s.job.completedAt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - completedAt
+      - name: k8s.job.specParallelism
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - specParallelism
+      - name: k8s.job.specCompletions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - specCompletions
+      - name: k8s.job.specActiveDeadlineSeconds
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - specActiveDeadlineSeconds
+      - name: k8s.job.activePods
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - activePods
+      - name: k8s.job.succeededPods
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - succeededPods
+      - name: k8s.job.failedPods
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sJobSample
+          legacyNames:
+            - failedPods
+    tags:
+      - name: k8s.clusterName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - clusterName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.namespaceName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - namespaceName
+            - namespace
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.jobName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - jobName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.job.isComplete
+        type: string
+        migrationInformation:
+          legacyNames:
+            - isComplete
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.job.failed
+        type: string
+        migrationInformation:
+          legacyNames:
+            - failed
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.job.failedPodsReason
+        type: string
+        migrationInformation:
+          legacyNames:
+            - failedPodsReason
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.job.ownerName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - ownerName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.job.ownerKind
+        type: string
+        migrationInformation:
+          legacyNames:
+            - ownerKind
+          legacyEventTypes:
+            - K8sJobSample
+      - name: k8s.job.ownerIsController
+        type: string
+        migrationInformation:
+          legacyNames:
+            - ownerIsController
+          legacyEventTypes:
+            - K8sJobSample
+      - name: entity.guid
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityGuid
+            - nr.entityGuid
+          legacyEventTypes:
+            - K8sJobSample
+      - name: entity.name
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: entity.id
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: tags.*
+        type: string
+        description: >-
+          These are user-defined tags (* matches any value configured by the customer)
+        migrationInformation:
+          legacyNames:
+            - label.*
+            - ec2Tag_*
+            - provider.ec2Tag_*
+            - tag_*
+          legacyEventTypes:
+            - K8sJobSample
+      - name: tags.container.*
+        type: string
+        description: >-
+          These are user-defined tags (* matches any value configured by the customer)
+        migrationInformation:
+          legacyNames:
+            - containerLabel_*
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.kernelVersion
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - kernelVersion
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.linuxDistribution
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - linuxDistribution
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.operatingSystem
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - operatingSystem
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.windowsFamily
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsFamily
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.windowsPlatform
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsPlatform
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.windowsVersion
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsVersion
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.instanceType
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - instanceType
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.hostname
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - hostname
+          legacyEventTypes:
+            - K8sJobSample
+      - name: host.fullHostname
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - fullHostname
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.region
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsRegion
+            - provider.awsRegion
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.accountId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsAccountId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.availabilityZone
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsAvailabilityZone
+            - provider.awsAvailabilityZone
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.InstanceId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2InstanceId
+            - provider.ec2InstanceId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.publicDnsName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PublicDnsName
+            - provider.ec2PublicDnsName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.state
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2State
+            - provider.ec2State
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.ebsOptimized
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2EbsOptimized
+            - provider.ec2EbsOptimized
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.publicIpAddress
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PublicIpAddress
+            - provider.ec2PublicIpAddress
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.privateIpAddress
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PrivateIpAddress
+            - provider.ec2PrivateIpAddress
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.vpcId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2VpcId
+            - provider.ec2VpcId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.amiId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2AmiId
+            - provider.ec2AmiId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.privateDnsName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PrivateDnsName
+            - provider.ec2PrivateDnsName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.keyName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2KeyName
+            - provider.ec2KeyName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.subnetId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2SubnetId
+            - provider.ec2SubnetId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.instanceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2InstanceType
+            - provider.ec2InstanceType
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.hypervisor
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2Hypervisor
+            - provider.ec2Hypervisor
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.architecture
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2Architecture
+            - provider.ec2Architecture
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.rootDeviceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2RootDeviceType
+            - provider.ec2RootDeviceType
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.rootDeviceName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2RootDeviceName
+            - provider.ec2RootDeviceName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.virtualizationType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2VirtualizationType
+            - provider.ec2VirtualizationType
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.placementGroupName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PlacementGroupName
+            - provider.ec2PlacementGroupName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.ec2.placementGroupTenancy
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PlacementGroupTenancy
+            - provider.ec2PlacementGroupTenancy
+          legacyEventTypes:
+            - K8sJobSample
+      - name: aws.arn
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - aws.arn
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.subscriptionId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - subscriptionId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.compute.virtualmachines.vmId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - vmId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.compute.virtualmachines.vmSize
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - vmSize
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.compute.virtualmachines.image
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - image
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.compute.virtualmachines.availabilitySet
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - availabilitySet
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.resourceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - type
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.region
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - regionName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: azure.resourceGroup
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - resourceGroupName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: gcp.compute.machineType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - machineType
+          legacyEventTypes:
+            - K8sJobSample
+      - name: gcp.compute.isPreemptible
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - isPreemptible
+          legacyEventTypes:
+            - K8sJobSample
+      - name: gcp.projectId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - projectId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: gcp.zone
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - zone
+          legacyEventTypes:
+            - K8sJobSample
+      - name: gcp.compute.status
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - status
+          legacyEventTypes:
+            - K8sJobSample
+    internalAttributes:
+      - name: newrelic.integrationName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - integrationName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.integrationVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - integrationVersion
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.agentVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - agentVersion
+          legacyEventTypes:
+            - K8sJobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+      - name: newrelic.reportingAgent
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingAgent
+          legacyEventTypes:
+            - K8sJobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+      - name: newrelic.reportingEndpoint
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingEndpoint
+          legacyEventTypes:
+            - K8sJobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+      - name: newrelic.reportingEntityKey
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingEntityKey
+          legacyEventTypes:
+            - K8sJobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+      - name: newrelic.hostId
+        type: string
+        migrationInformation:
+          legacyNames:
+            - hostID
+          legacyEventTypes:
+            - K8sJobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+      - name: newrelic.countersSource
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - countersSource
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.entityAndPid
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndPid
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.entityAndMountPoint
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndMountPoint
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.entityAndInterface
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndInterface
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.cloudIntegrations.integrationId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - dataSourceId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.cloudIntegrations.integrationName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - dataSourceName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.cloudIntegrations.providerAccountId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerAccountId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.cloudIntegrations.providerAccountName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerAccountName
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.cloudIntegrations.providerExternalId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerExternalId
+          legacyEventTypes:
+            - K8sJobSample
+      - name: nr.cloudVmType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - nr.cloudVmType
+          legacyEventTypes:
+            - K8sJobSample
+      - name: nr.performanceMetricsEnabled
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - nr.performanceMetricsEnabled
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.apmApplicationNames
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - apmApplicationNames
+          legacyEventTypes:
+            - K8sJobSample
+      - name: newrelic.apmApplicationIds
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - apmApplicationIds
+          legacyEventTypes:
+            - K8sJobSample
+    ignoredAttributes:
+      - agentName
+      - coreCount
+      - processorCount
+      - systemMemoryBytes
+      - entityKey
+      - externalKey
+      - warningViolationCount
+      - criticalViolationCount
+      - displayName
+      - event_type
+      - provider
+      - networkTag.*
   - entityType: K8sNamespace
     metrics:
       - name: k8s.namespace.createdAt

--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -2535,6 +2535,784 @@ entities:
       - event_type
       - provider
       - networkTag.*
+  - entityType: K8sCronjob
+    metrics:
+      - name: k8s.cronjob.createdAt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - createdAt
+      - name: k8s.cronjob.isActive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - isActive
+      - name: k8s.cronjob.nextScheduledTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - nextScheduledTime
+      - name: k8s.cronjob.lastScheduledTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - lastScheduledTime
+      - name: k8s.cronjob.isSuspended
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - isSuspended
+      - name: k8s.cronjob.specStartingDeadlineSeconds
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - specStartingDeadlineSeconds
+      - name: k8s.cronjob.metadataResourceVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        migrationInformation:
+          legacyEventType: K8sCronjobSample
+          legacyNames:
+            - metadataResourceVersion
+    tags:
+      - name: k8s.clusterName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - clusterName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: k8s.namespaceName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - namespaceName
+            - namespace
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: k8s.cronjobName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - cronjobName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: k8s.cronjob.schedule
+        type: string
+        migrationInformation:
+          legacyNames:
+            - schedule
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: k8s.cronjob.concurrencyPolicy
+        type: string
+        migrationInformation:
+          legacyNames:
+            - concurrencyPolicy
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: entity.guid
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityGuid
+            - nr.entityGuid
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: entity.name
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: entity.id
+        type: string
+        description: >-
+          This is an attribute that defines the entity, which is added in the ingestion pipeline.
+        migrationInformation:
+          legacyNames:
+            - entityId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: tags.*
+        type: string
+        description: >-
+          These are user-defined tags (* matches any value configured by the customer)
+        migrationInformation:
+          legacyNames:
+            - label.*
+            - ec2Tag_*
+            - provider.ec2Tag_*
+            - tag_*
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: tags.container.*
+        type: string
+        description: >-
+          These are user-defined tags (* matches any value configured by the customer)
+        migrationInformation:
+          legacyNames:
+            - containerLabel_*
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.kernelVersion
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - kernelVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.linuxDistribution
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - linuxDistribution
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.operatingSystem
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - operatingSystem
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.windowsFamily
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsFamily
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.windowsPlatform
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsPlatform
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.windowsVersion
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - windowsVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.instanceType
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - instanceType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.hostname
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - hostname
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: host.fullHostname
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the entity.
+        migrationInformation:
+          legacyNames:
+            - fullHostname
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.region
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsRegion
+            - provider.awsRegion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.accountId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsAccountId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.availabilityZone
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - awsAvailabilityZone
+            - provider.awsAvailabilityZone
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.InstanceId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2InstanceId
+            - provider.ec2InstanceId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.publicDnsName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PublicDnsName
+            - provider.ec2PublicDnsName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.state
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2State
+            - provider.ec2State
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.ebsOptimized
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2EbsOptimized
+            - provider.ec2EbsOptimized
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.publicIpAddress
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PublicIpAddress
+            - provider.ec2PublicIpAddress
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.privateIpAddress
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PrivateIpAddress
+            - provider.ec2PrivateIpAddress
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.vpcId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2VpcId
+            - provider.ec2VpcId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.amiId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2AmiId
+            - provider.ec2AmiId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.privateDnsName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PrivateDnsName
+            - provider.ec2PrivateDnsName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.keyName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2KeyName
+            - provider.ec2KeyName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.subnetId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2SubnetId
+            - provider.ec2SubnetId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.instanceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2InstanceType
+            - provider.ec2InstanceType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.hypervisor
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2Hypervisor
+            - provider.ec2Hypervisor
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.architecture
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2Architecture
+            - provider.ec2Architecture
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.rootDeviceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2RootDeviceType
+            - provider.ec2RootDeviceType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.rootDeviceName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2RootDeviceName
+            - provider.ec2RootDeviceName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.virtualizationType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2VirtualizationType
+            - provider.ec2VirtualizationType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.placementGroupName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PlacementGroupName
+            - provider.ec2PlacementGroupName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.ec2.placementGroupTenancy
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - ec2PlacementGroupTenancy
+            - provider.ec2PlacementGroupTenancy
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: aws.arn
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - aws.arn
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.subscriptionId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - subscriptionId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.vmId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - vmId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.vmSize
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - vmSize
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.image
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - image
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.compute.virtualmachines.availabilitySet
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - availabilitySet
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.resourceType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - type
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.region
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - regionName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: azure.resourceGroup
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - resourceGroupName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.compute.machineType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - machineType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.compute.isPreemptible
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - isPreemptible
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.projectId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - projectId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.zone
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - zone
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: gcp.compute.status
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2, Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - status
+          legacyEventTypes:
+            - K8sCronjobSample
+    internalAttributes:
+      - name: newrelic.integrationName
+        type: string
+        migrationInformation:
+          legacyNames:
+            - integrationName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.integrationVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - integrationVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.agentVersion
+        type: string
+        migrationInformation:
+          legacyNames:
+            - agentVersion
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.reportingAgent
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingAgent
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.reportingEndpoint
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingEndpoint
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.reportingEntityKey
+        type: string
+        migrationInformation:
+          legacyNames:
+            - reportingEntityKey
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.hostId
+        type: string
+        migrationInformation:
+          legacyNames:
+            - hostID
+          legacyEventTypes:
+            - K8sCronjobSample
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+      - name: newrelic.countersSource
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - countersSource
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.entityAndPid
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndPid
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.entityAndMountPoint
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndMountPoint
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.entityAndInterface
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - entityAndInterface
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.integrationId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - dataSourceId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.integrationName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - dataSourceName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.providerAccountId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerAccountId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.providerAccountName
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerAccountName
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.cloudIntegrations.providerExternalId
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - providerExternalId
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: nr.cloudVmType
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - nr.cloudVmType
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: nr.performanceMetricsEnabled
+        type: string
+        description: >-
+          This is an attribute which comes from Cloud VMs integrations (AWS EC2,
+          Azure VMs, GCP VMs) if they are enabled.
+        migrationInformation:
+          legacyNames:
+            - nr.performanceMetricsEnabled
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.apmApplicationNames
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - apmApplicationNames
+          legacyEventTypes:
+            - K8sCronjobSample
+      - name: newrelic.apmApplicationIds
+        type: string
+        description: >-
+          This is an attribute which comes from the host that is reporting the
+          entity.
+        migrationInformation:
+          legacyNames:
+            - apmApplicationIds
+          legacyEventTypes:
+            - K8sCronjobSample
+    ignoredAttributes:
+      - agentName
+      - coreCount
+      - processorCount
+      - systemMemoryBytes
+      - entityKey
+      - externalKey
+      - warningViolationCount
+      - criticalViolationCount
+      - displayName
+      - event_type
+      - provider
+      - networkTag.*
   - entityType: K8sDaemonset
     metrics:
       - name: k8s.daemonset.createdAt

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -43,8 +43,14 @@ func TestScraper(t *testing.T) {
 				exclude.Groups("horizontalpodautoscaler"),
 				exclude.Metrics("isActive", "isAble", "isLimited"),
 			),
+			// Kubernetes jobs either succeed or fail (but not both). Thus, the KSM metrics related to success (isComplete, completedAt)
+			// and failure (failed, failedPods, failedPodsReason) are marked as optional in src/metric/definition.go
+			exclude.Exclude(
+				exclude.Groups("job_name"),
+				exclude.Optional(),
+			),
 		).
-		AliasingGroups(map[string]string{"horizontalpodautoscaler": "hpa"})
+		AliasingGroups(map[string]string{"horizontalpodautoscaler": "hpa", "job_name": "job"})
 
 	for _, v := range testutil.AllVersions() {
 		// Make a copy of the version variable to use it concurrently

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -565,6 +565,26 @@ var EtcdQueries = []prometheus.Query{
 
 // KSMSpecs are the metric specifications we want to collect from KSM.
 var KSMSpecs = definition.SpecGroups{
+	"cronjob": {
+		IDGenerator:     prometheus.FromLabelValueEntityIDGenerator("kube_cronjob_created", "cronjob"),
+		TypeGenerator:   prometheus.FromLabelValueEntityTypeGenerator("kube_cronjob_created"),
+		NamespaceGetter: prometheus.FromLabelGetNamespace,
+		Specs: []definition.Spec{
+			{Name: "createdAt", ValueFunc: prometheus.FromValue("kube_cronjob_created"), Type: sdkMetric.GAUGE},
+			{Name: "isActive", ValueFunc: prometheus.FromValue("kube_cronjob_status_active"), Type: sdkMetric.GAUGE},
+			{Name: "nextScheduledTime", ValueFunc: prometheus.FromValue("kube_cronjob_next_schedule_time"), Type: sdkMetric.GAUGE},
+			{Name: "lastScheduledTime", ValueFunc: prometheus.FromValue("kube_cronjob_status_last_schedule_time"), Type: sdkMetric.GAUGE},
+			{Name: "isSuspended", ValueFunc: prometheus.FromValue("kube_cronjob_spec_suspend"), Type: sdkMetric.GAUGE},
+			{Name: "specStartingDeadlineSeconds", ValueFunc: prometheus.FromValue("kube_cronjob_spec_starting_deadline_seconds"), Type: sdkMetric.GAUGE},
+			{Name: "metadataResourceVersion", ValueFunc: prometheus.FromValue("kube_cronjob_metadata_resource_version"), Type: sdkMetric.GAUGE},
+			{Name: "cronjobName", ValueFunc: prometheus.FromLabelValue("kube_cronjob_created", "cronjob"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_cronjob_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_cronjob_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "label.*", ValueFunc: prometheus.InheritAllLabelsFrom("cronjob", "kube_cronjob_labels"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "schedule", ValueFunc: prometheus.FromLabelValue("kube_cronjob_info", "schedule"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "concurrencyPolicy", ValueFunc: prometheus.FromLabelValue("kube_cronjob_info", "concurrency_policy"), Type: sdkMetric.ATTRIBUTE},
+		},
+	},
 	"replicaset": {
 		IDGenerator:     prometheus.FromLabelValueEntityIDGenerator("kube_replicaset_created", "replicaset"),
 		TypeGenerator:   prometheus.FromLabelValueEntityTypeGenerator("kube_replicaset_created"),
@@ -828,6 +848,17 @@ var KSMSpecs = definition.SpecGroups{
 
 // KSMQueries are the queries we will do to KSM in order to fetch all the raw metrics.
 var KSMQueries = []prometheus.Query{
+	{MetricName: "kube_cronjob_info"},
+	{MetricName: "kube_cronjob_labels", Value: prometheus.QueryValue{
+		Value: prometheus.GaugeValue(1),
+	}},
+	{MetricName: "kube_cronjob_created"},
+	{MetricName: "kube_cronjob_next_schedule_time"},
+	{MetricName: "kube_cronjob_status_active"},
+	{MetricName: "kube_cronjob_status_last_schedule_time"},
+	{MetricName: "kube_cronjob_spec_suspend"},
+	{MetricName: "kube_cronjob_spec_starting_deadline_seconds"},
+	{MetricName: "kube_cronjob_metadata_resource_version"},
 	{MetricName: "kube_statefulset_replicas"},
 	{MetricName: "kube_statefulset_status_replicas_ready"},
 	{MetricName: "kube_statefulset_status_replicas"},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -585,6 +585,33 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "concurrencyPolicy", ValueFunc: prometheus.FromLabelValue("kube_cronjob_info", "concurrency_policy"), Type: sdkMetric.ATTRIBUTE},
 		},
 	},
+	"job_name": {
+		IDGenerator:     prometheus.FromLabelValueEntityIDGenerator("kube_job_created", "job_name"),
+		TypeGenerator:   prometheus.FromLabelValueEntityTypeGeneratorWithCustomGroup("kube_job_created", "job"),
+		NamespaceGetter: prometheus.FromLabelGetNamespace,
+		MsTypeGuesser:   metricSetTypeGuesserWithCustomGroup("job"),
+		Specs: []definition.Spec{
+			{Name: "createdAt", ValueFunc: prometheus.FromValue("kube_job_created"), Type: sdkMetric.GAUGE},
+			{Name: "startedAt", ValueFunc: prometheus.FromValue("kube_job_status_start_time"), Type: sdkMetric.GAUGE},
+			{Name: "completedAt", ValueFunc: prometheus.FromValue("kube_job_status_completion_time"), Type: sdkMetric.GAUGE, Optional: true},
+			{Name: "specParallelism", ValueFunc: prometheus.FromValue("kube_job_spec_parallelism"), Type: sdkMetric.GAUGE},
+			{Name: "specCompletions", ValueFunc: prometheus.FromValue("kube_job_spec_completions"), Type: sdkMetric.GAUGE},
+			{Name: "specActiveDeadlineSeconds", ValueFunc: prometheus.FromValue("kube_job_spec_active_deadline_seconds"), Type: sdkMetric.GAUGE, Optional: true},
+			{Name: "activePods", ValueFunc: prometheus.FromValue("kube_job_status_active"), Type: sdkMetric.GAUGE},
+			{Name: "succeededPods", ValueFunc: prometheus.FromValue("kube_job_status_succeeded"), Type: sdkMetric.GAUGE},
+			{Name: "failedPods", ValueFunc: prometheus.FromValue("kube_job_status_failed"), Type: sdkMetric.GAUGE, Optional: true},
+			{Name: "isComplete", ValueFunc: prometheus.FromLabelValue("kube_job_complete", "condition"), Type: sdkMetric.ATTRIBUTE, Optional: true},
+			{Name: "failed", ValueFunc: prometheus.FromLabelValue("kube_job_failed", "condition"), Type: sdkMetric.ATTRIBUTE, Optional: true},
+			{Name: "failedPodsReason", ValueFunc: prometheus.FromLabelValue("kube_job_status_failed", "reason"), Type: sdkMetric.ATTRIBUTE, Optional: true},
+			{Name: "ownerName", ValueFunc: prometheus.FromLabelValue("kube_job_owner", "owner_name"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "ownerKind", ValueFunc: prometheus.FromLabelValue("kube_job_owner", "owner_kind"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "ownerIsController", ValueFunc: prometheus.FromLabelValue("kube_job_owner", "owner_is_controller"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "jobName", ValueFunc: prometheus.FromLabelValue("kube_job_created", "job_name"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_job_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_job_created", "namespace"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "label.*", ValueFunc: prometheus.InheritAllLabelsFrom("job_name", "kube_job_labels"), Type: sdkMetric.ATTRIBUTE},
+		},
+	},
 	"replicaset": {
 		IDGenerator:     prometheus.FromLabelValueEntityIDGenerator("kube_replicaset_created", "replicaset"),
 		TypeGenerator:   prometheus.FromLabelValueEntityTypeGenerator("kube_replicaset_created"),
@@ -859,6 +886,53 @@ var KSMQueries = []prometheus.Query{
 	{MetricName: "kube_cronjob_spec_suspend"},
 	{MetricName: "kube_cronjob_spec_starting_deadline_seconds"},
 	{MetricName: "kube_cronjob_metadata_resource_version"},
+	{MetricName: "kube_job_info"},
+	{MetricName: "kube_job_labels", Value: prometheus.QueryValue{
+		Value: prometheus.GaugeValue(1),
+	}},
+	{MetricName: "kube_job_owner"},
+	{MetricName: "kube_job_spec_parallelism"},
+	{MetricName: "kube_job_spec_completions"},
+	{MetricName: "kube_job_spec_active_deadline_seconds"},
+	{MetricName: "kube_job_status_active"},
+	{MetricName: "kube_job_status_succeeded"},
+	{MetricName: "kube_job_status_failed", Value: prometheus.QueryValue{
+		// Since we aggregate metrics which look like the following:
+		//
+		// kube_job_status_failed{namespace="default",job_name="e2e-resources-failjob",reason="BackoffLimitExceeded"} 1
+		// kube_job_status_failed{namespace="default",job_name="e2e-resources-failjob",reason="DeadLineExceeded"} 0
+		// kube_job_status_failed{namespace="default",job_name="e2e-resources-failjob",reason="Evicted"} 0
+		// kube_job_status_failed{namespace="default",job_name="e2e-resources-cronjob-27931661"} 0
+		//
+		// KSM should never produce a positive value for more than one status, so we can simply fetch
+		// only values which has value 1 for processing.
+		Value: prometheus.GaugeValue(1),
+	}},
+	{MetricName: "kube_job_status_start_time"},
+	{MetricName: "kube_job_status_completion_time"},
+	{MetricName: "kube_job_complete", Value: prometheus.QueryValue{
+		// Since we aggregate metrics which look like the following:
+		//
+		// kube_job_complete{namespace="default",job_name="e2e-resources-cronjob",condition="true"} 1
+		// kube_job_complete{namespace="default",job_name="e2e-resources-cronjob",condition="false"} 0
+		// kube_job_complete{namespace="default",job_name="e2e-resources-cronjob",condition="unknown"} 0
+		//
+		// KSM should never produce a positive value for more than one status, so we can simply fetch
+		// only values which has value 1 for processing.
+		Value: prometheus.GaugeValue(1),
+	}},
+	{MetricName: "kube_job_failed", Value: prometheus.QueryValue{
+		// Since we aggregate metrics which look like the following:
+		//
+		// kube_job_failed{namespace="default",job_name="e2e-resources-failjob",condition="true"} 1
+		// kube_job_failed{namespace="default",job_name="e2e-resources-failjob",condition="false"} 0
+		// kube_job_failed{namespace="default",job_name="e2e-resources-failjob",condition="unknown"} 0
+		//
+		// KSM should never produce a positive value for more than one status, so we can simply fetch
+		// only values which has value 1 for processing.
+		Value: prometheus.GaugeValue(1),
+	}},
+	{MetricName: "kube_job_created"},
 	{MetricName: "kube_statefulset_replicas"},
 	{MetricName: "kube_statefulset_status_replicas_ready"},
 	{MetricName: "kube_statefulset_status_replicas"},


### PR DESCRIPTION
We are ready to release Kubernetes `CronJob` and `Job` metrics. 

This PR adds the following two commits using `git cherry-pick`:
- Add CronJob KSM metrics. (#609)
- Add Job KSM metrics. (#626)

Both commits were previously reverted in https://github.com/newrelic/nri-kubernetes/pull/688. However, PR #688 reverted other commits (including #629 and #639) so I couldn't revert #688 directly since we only want to release 2 of those commits now. 
