### PR TITLE
Adding new attribute `ReplicaFailure` to deployment workload

### DIFF
--- a/e2e/k8s.yml
+++ b/e2e/k8s.yml
@@ -4288,18 +4288,25 @@ entities:
             - namespace
           legacyEventTypes:
             - K8sDeploymentSample
-      - name: k8s.deployment.isAvailable
+      - name: k8s.deployment.conditionAvailable
         type: string
         migrationInformation:
           legacyNames:
-            - isAvailable
+            - conditionAvailable
           legacyEventTypes:
             - K8sDeploymentSample
-      - name: k8s.deployment.isProgressing
+      - name: k8s.deployment.conditionProgressing
         type: string
         migrationInformation:
           legacyNames:
-            - isProgressing
+            - conditionProgressing
+          legacyEventTypes:
+            - K8sDeploymentSample
+      - name: k8s.deployment.conditionReplicaFailure
+        type: string
+        migrationInformation:
+          legacyNames:
+            - conditionReplicaFailure
           legacyEventTypes:
             - K8sDeploymentSample
       - name: entity.guid

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -49,6 +49,11 @@ func TestScraper(t *testing.T) {
 				exclude.Groups("job_name"),
 				exclude.Optional(),
 			),
+			// Kubernetes deployment's `condition` attribute operate in a true-or-NULL basis, so it won't be present if false
+			exclude.Exclude(
+				exclude.Groups("deployment"),
+				exclude.Optional(),
+			),
 		).
 		AliasingGroups(map[string]string{"horizontalpodautoscaler": "hpa", "job_name": "job"})
 

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -725,7 +725,7 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "metadataGeneration", ValueFunc: prometheus.FromValue("kube_deployment_metadata_generation"), Type: sdkMetric.GAUGE},
 			{Name: "conditionAvailable", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_available", "status"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "conditionProgressing", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_progressing", "status"), Type: sdkMetric.ATTRIBUTE},
-			{Name: "conditionReplicaFailure", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_replica_failure", "status"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "conditionReplicaFailure", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_replica_failure", "status"), Type: sdkMetric.ATTRIBUTE, Optional: true},
 			{Name: "podsMaxUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_unavailable"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -723,8 +723,9 @@ var KSMSpecs = definition.SpecGroups{
 			{Name: "isPaused", ValueFunc: prometheus.FromValue("kube_deployment_spec_paused"), Type: sdkMetric.GAUGE},
 			{Name: "rollingUpdateMaxPodsSurge", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_surge"), Type: sdkMetric.GAUGE},
 			{Name: "metadataGeneration", ValueFunc: prometheus.FromValue("kube_deployment_metadata_generation"), Type: sdkMetric.GAUGE},
-			{Name: "isAvailable", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_available", "status"), Type: sdkMetric.ATTRIBUTE},
-			{Name: "isProgressing", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_progressing", "status"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "conditionAvailable", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_available", "status"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "conditionProgressing", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_progressing", "status"), Type: sdkMetric.ATTRIBUTE},
+			{Name: "conditionReplicaFailure", ValueFunc: prometheus.FromLabelValue("kube_deployment_status_condition_replica_failure", "status"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "podsMaxUnavailable", ValueFunc: prometheus.FromValue("kube_deployment_spec_strategy_rollingupdate_max_unavailable"), Type: sdkMetric.GAUGE, Optional: true},
 			{Name: "namespace", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
 			{Name: "namespaceName", ValueFunc: prometheus.FromLabelValue("kube_deployment_labels", "namespace"), Type: sdkMetric.ATTRIBUTE},
@@ -1019,6 +1020,16 @@ var KSMQueries = []prometheus.Query{
 		CustomName: "kube_deployment_status_condition_progressing",
 		Labels: prometheus.QueryLabels{
 			Labels: prometheus.Labels{"condition": "Progressing"},
+		},
+		Value: prometheus.QueryValue{
+			Value: prometheus.GaugeValue(1),
+		},
+	},
+	{
+		MetricName: "kube_deployment_status_condition",
+		CustomName: "kube_deployment_status_condition_replica_failure",
+		Labels: prometheus.QueryLabels{
+			Labels: prometheus.Labels{"condition": "ReplicaFailure"},
 		},
 		Value: prometheus.QueryValue{
 			Value: prometheus.GaugeValue(1),


### PR DESCRIPTION
# Description
The Kubernetes team is updating metrics for all supported workloads and services. Specifically, [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) has upgraded several metrics and services from `experimental` to `stable`.

We noted in the Kubernetes repository that there are [only three valid conditions of a deployment](https://github.com/kubernetes/kubernetes/blob/3615291/pkg/apis/apps/types.go#L460-L473):
- `Available`
- `Progressing`
- `ReplicaFailure`

While they are [briefly mentioned in the documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/), there is no statement indicating they are the only valid conditions.

# PR Changes
This PR makes changes to the agent to start scraping the attribute `ReplicaFailure` from [KSM's metric `kube_deployment_status_condition`](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/deployment-metrics.md#deployment-metrics) to make sure we scrape all valid conditions for Deployment workloads.

# Related PRs
[nri-kubernetes #725](https://github.com/newrelic/nri-kubernetes/pull/725)
[infra-integration-specs #313](https://source.datanerd.us/infrastructure/infra-integration-specs/pull/313)
[infra-metrics-utils #85](https://source.datanerd.us/infrastructure/infra-metrics-utils/pull/85)
[dirac #8087](https://source.datanerd.us/dirac/dirac/pull/8087)
[dirac_async_query_service #3347](https://source.datanerd.us/events-pipeline/dirac_async_query_service/pull/3347)
[window-aggregation-merger #811](https://source.datanerd.us/events-pipeline/window-aggregation-merger/pull/811)
[partial-aggregation-windower #529](https://source.datanerd.us/events-pipeline/partial-aggregation-windower/pull/529)

# Testing Plan
- [x] Run local testing environment and check metrics are ingested to NR1 in the respective `K8s*Sample` tables