### PR TITLE
Fix push_pr workflow

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -60,7 +60,7 @@ jobs:
 
           for chart in $(ct --config .github/ct.yaml list-changed); do
             if [ -d "$chart/tests/" ]; then
-              helm unittest -3 $chart
+              helm unittest $chart
             else
               echo "No unit tests found for $chart"
             fi


### PR DESCRIPTION
Fixes https://github.com/newrelic/nri-kubernetes/actions/runs/4734869907/jobs/8404363346?pr=721.

Now that https://github.com/helm-unittest/helm-unittest/pull/114 has made Helm3 support the default, we no longer need to specify Helm3.
