### PR TITLE
chore(deps): bump aquasecurity/trivy-action from 0.9.2 to 0.10.0

### DIFF
--- a/.github/workflows/nightlyAndMainImage.yml
+++ b/.github/workflows/nightlyAndMainImage.yml
@@ -74,7 +74,7 @@ jobs:
             -t $DOCKER_IMAGE_NAME:ci-scan \
             .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.9.2
+        uses: aquasecurity/trivy-action@0.10.0
         with:
           image-ref: '${{ env.DOCKER_IMAGE_NAME }}:ci-scan'
           format: 'table'

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -65,7 +65,7 @@ jobs:
             -t $DOCKER_IMAGE_NAME:ci-scan \
             .
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.9.2
+        uses: aquasecurity/trivy-action@0.10.0
         with:
           image-ref: '${{ env.DOCKER_IMAGE_NAME }}:ci-scan'
           format: 'table'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.9.2
+        uses: aquasecurity/trivy-action@0.10.0
         if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
         with:
           scan-type: fs
@@ -28,7 +28,7 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Run Trivy vulnerability scanner sarif output
-        uses: aquasecurity/trivy-action@0.9.2
+        uses: aquasecurity/trivy-action@0.10.0
         if: ${{ github.event.schedule }} # Generate sarif when running periodically
         with:
           scan-type: fs


### PR DESCRIPTION
Recreating https://github.com/newrelic/nri-kubernetes/pull/723 because dependabot PRs don't work with E2E testing.
