### PR TITLE
(Fix) Updating helm charts to support version 3 windows integration

### DIFF
--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -169,7 +169,7 @@ integrations that you have configured.
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
 | kubelet.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
-| kubelet.windowsOsList | list | `[]` | List of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022 |
+| kubelet.windowsOsList | list | `[]` | `windowsOsList` is only required if `enableWindows` is true. It contains list of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022 |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |
 | lowDataMode | bool | `false` (See [Low data mode](README.md#low-data-mode)) | Send less data by incrementing the interval from `15s` (the default when `lowDataMode` is `false` or `nil`) to `30s`. Non-nil values of `common.config.interval` will override this value. |

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -169,7 +169,6 @@ integrations that you have configured.
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
 | kubelet.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
-| kubelet.enableWindows | bool | `false` | Set to enable Windows node monitoring. |
 | kubelet.windowsOsList | list | `[]` | List of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022 |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -161,6 +161,7 @@ integrations that you have configured.
 | kubelet.config.retries | int | `3` | Number of retries after timeout expired |
 | kubelet.config.scraperMaxReruns | int | `4` | Max number of scraper rerun when scraper runtime error happens |
 | kubelet.config.timeout | string | `"10s"` | Timeout for the kubelet APIs contacted by the integration |
+| kubelet.enableWindows | bool | `false` | Enable Windows monitoring and update `windowsOsList` with the list of Windows versions present in the cluster. |
 | kubelet.enabled | bool | `true` | Enable kubelet monitoring. Advanced users only. Setting this to `false` is not supported and will break the New Relic experience. |
 | kubelet.extraEnv | list | `[]` | Add user environment variables to the agent |
 | kubelet.extraEnvFrom | list | `[]` | Add user environment from configMaps or secrets as variables to the agent |
@@ -168,6 +169,8 @@ integrations that you have configured.
 | kubelet.extraVolumes | list | `[]` | Volumes to mount in the containers |
 | kubelet.hostNetwork | bool | Not set | Sets pod's hostNetwork. When set bypasses global/common variable |
 | kubelet.tolerations | list | Schedules in all tainted nodes | Tolerations for the control plane DaemonSet. |
+| kubelet.enableWindows | bool | `false` | Set to enable Windows node monitoring. |
+| kubelet.windowsOsList | list | `[]` | List of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022 |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |
 | licenseKey | string | `""` | This set this license key to use. Can be configured also with `global.licenseKey` |
 | lowDataMode | bool | `false` (See [Low data mode](README.md#low-data-mode)) | Send less data by incrementing the interval from `15s` (the default when `lowDataMode` is `false` or `nil`) to `30s`. Non-nil values of `common.config.interval` will override this value. |

--- a/charts/newrelic-infrastructure/templates/NOTES.txt
+++ b/charts/newrelic-infrastructure/templates/NOTES.txt
@@ -110,10 +110,6 @@ future. Please migrate your agent config to the new format in the `common.agentC
 {{ $errors = printf "%s\n\n%s" $errors (include "newrelic.compatibility.message.image" . ) }}
 {{- end }}
 
-{{- if .Values.enableWindows }}
-{{ $errors = printf "%s\n\n%s" $errors (include "newrelic.compatibility.message.windows" . ) }}
-{{- end }}
-
 {{- if ( or .Values.controllerManagerEndpointUrl  .Values.schedulerEndpointUrl .Values.etcdEndpointUrl .Values.apiServerEndpointUrl )}}
 {{ $errors = printf "%s\n\n%s" $errors (include "newrelic.compatibility.message.apiURL" . ) }}
 {{- end }}

--- a/charts/newrelic-infrastructure/templates/_helpers_compatibility.tpl
+++ b/charts/newrelic-infrastructure/templates/_helpers_compatibility.tpl
@@ -123,13 +123,6 @@ Please configure the API Server port as a part of 'apiServer.autodiscover[].endp
 ------
 {{- end -}}
 
-{{- define "newrelic.compatibility.message.windows" -}}
-nri-kubernetes v3 does not support deploying into windows Nodes.
-Please use the latest 2.x version of the chart.
-
-------
-{{- end -}}
-
 {{- define "newrelic.compatibility.message.etcdSecrets" -}}
 Values "etcdTlsSecretName" and "etcdTlsSecretNamespace" are no longer supported, please specify them as a part of the
 'etcd' config in the values, for example:

--- a/charts/newrelic-infrastructure/templates/clusterrole.yaml
+++ b/charts/newrelic-infrastructure/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
       - "services"
       - "nodes"
       - "namespaces"
+      - "pods" # For Windows integration, Pods required in list of resources
     verbs: [ "get", "list", "watch" ]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]

--- a/charts/newrelic-infrastructure/templates/clusterrole.yaml
+++ b/charts/newrelic-infrastructure/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
       - "services"
       - "nodes"
       - "namespaces"
-      - "pods" # For Windows integration, Pods required in list of resources
+      - "pods" # Needed for our Windows integration to be able to access KSM on a Linux node.
     verbs: [ "get", "list", "watch" ]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]

--- a/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
+++ b/charts/newrelic-infrastructure/templates/ksm/deployment.yaml
@@ -184,8 +184,9 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with .Values.ksm.nodeSelector | default (fromYaml (include "newrelic.common.nodeSelector" .)) }}
       nodeSelector:
+        kubernetes.io/os: linux
+      {{- with .Values.ksm.nodeSelector | default (fromYaml (include "newrelic.common.nodeSelector" .)) }}
         {{- toYaml . | nindent 8 }}
       {{- end -}}
 {{- end }}

--- a/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
@@ -3,6 +3,10 @@
 {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet") -}}
 {{- end -}}
 
+{{- define "nriKubernetes.kubelet.windows.fullname" -}}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "windows") -}}
+{{- end -}}
+
 {{- define "nriKubernetes.kubelet.fullname.agent" -}}
 {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent-kubelet") -}}
 {{- end -}}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.kubelet.enabled .Values.kubelet.enableWindows }}
+{{- range .Values.kubelet.windowsOsList }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: {{ $.Release.Namespace }}
+  name: {{ include "nriKubernetes.kubelet.windows.fullname" $ }}-{{ .version }}
+  {{- $legacyAnnotation:= fromYaml (include "newrelic.compatibility.annotations" $) -}}
+  {{- with  include "newrelic.compatibility.valueWithFallback" (dict "legacy" $legacyAnnotation "supported" $.Values.kubelet.annotations )}}
+  annotations: {{ . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $.Values.updateStrategy }}
+  updateStrategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "newrelic.common.labels.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: kubelet
+  template:
+    metadata:
+      annotations:
+        checksum/nri-kubernetes: {{ include (print $.Template.BasePath "/kubelet/scraper-configmap.yaml") $ | sha256sum }}
+        checksum/agent-config: {{ include (print $.Template.BasePath "/kubelet/agent-configmap.yaml") $ | sha256sum }}
+        {{- if include "newrelic.common.license.secret" $ }}{{- /* If the is secret to template */}}
+        checksum/license-secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
+        {{- end }}
+      labels:
+        {{- include "nriKubernetes.labels.podLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: kubelet
+    spec:
+      {{- with include "newrelic.common.dnsConfig" $ }}
+      dnsConfig:
+        {{- . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "newrelic.common.serviceAccount.name" $ }}
+      containers:
+        - name: agent
+          image: newrelic/infrastructure-k8s:{{ .imageTag }}
+          imagePullPolicy: {{ $.Values.images.integration.pullPolicy }}
+          env:
+            - name: NRIA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "newrelic.common.license.secretName" $ }}
+                  key: {{ include "newrelic.common.license.secretKeyName" $ }}
+            - name: "NRI_KUBERNETES_CLUSTERNAME"
+              value: {{ include "newrelic.common.cluster" $ }}
+            - name: "NRI_KUBERNETES_VERBOSE"
+              value: {{ include "newrelic.common.verboseLog.valueAsBoolean" $ | quote }}
+            - name: "NRK8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
+            - name: "CLUSTER_NAME"
+              value: {{ include "newrelic.common.cluster" $ }}
+            - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,ETCD_TLS_SECRET_NAME,ETCD_TLS_SECRET_NAMESPACE,API_SERVER_SECURE_PORT,NRIA_CACHE_PATH,TIMEOUT,DISCOVERY_CACHE_TTL"
+      nodeSelector:
+        node.kubernetes.io/windows-build: {{ .buildNumber }}
+        kubernetes.io/os: windows
+      tolerations:
+        - key: "node.kubernetes.io/os"
+          operator: "Equal"
+          value: "windows"
+          effect: "NoSchedule"
+---
+{{- end }}
+{{- end }}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -251,8 +251,9 @@ spec:
       tolerations:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- with .Values.kubelet.nodeSelector | default (fromYaml (include "newrelic.common.nodeSelector" .)) }}
       nodeSelector:
+        kubernetes.io/os: linux 
+      {{- with .Values.kubelet.nodeSelector | default (fromYaml (include "newrelic.common.nodeSelector" .)) }}
         {{- toYaml . | nindent 8 }}
       {{- end -}}
 {{- end }}

--- a/charts/newrelic-infrastructure/tests/nodeSelectors_test.yaml
+++ b/charts/newrelic-infrastructure/tests/nodeSelectors_test.yaml
@@ -25,6 +25,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -49,6 +50,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -76,6 +78,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: real
+            kubernetes.io/os: linux
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -103,6 +106,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: real
+            kubernetes.io/os: linux
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -130,6 +134,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -157,6 +162,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/ksm/deployment.yaml
       - equal:
           path: spec.template.spec.nodeSelector

--- a/charts/newrelic-infrastructure/tests/nodeSelectors_test.yaml
+++ b/charts/newrelic-infrastructure/tests/nodeSelectors_test.yaml
@@ -30,6 +30,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/kubelet/daemonset.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -53,6 +54,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/kubelet/daemonset.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -79,6 +81,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: real
+            kubernetes.io/os: linux
         template: templates/kubelet/daemonset.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -105,6 +108,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/kubelet/daemonset.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -131,6 +135,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: real
+            kubernetes.io/os: linux
         template: templates/kubelet/daemonset.yaml
       - equal:
           path: spec.template.spec.nodeSelector
@@ -157,6 +162,7 @@ tests:
           path: spec.template.spec.nodeSelector
           value:
             disktype: ssd
+            kubernetes.io/os: linux
         template: templates/kubelet/daemonset.yaml
       - equal:
           path: spec.template.spec.nodeSelector

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -86,7 +86,7 @@ kubelet:
   # -- Enable Windows monitoring and update `windowsOsList` with the list of Windows versions present in the cluster.
   enableWindows: false
   # --  List of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022
-  windowsOsList:
+  windowsOsList: []
   #  - version: 2019
   #    imageTag: 2-windows-1809-alpha
   #    buildNumber: 10.0.17763

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -83,6 +83,19 @@ kubelet:
   # -- Enable kubelet monitoring.
   # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
+  # -- Enable Windows monitoring and update `windowsOsList` with the list of Windows versions present in the cluster.
+  enableWindows: false
+  # --  List of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022
+  windowsOsList:
+  #  - version: 2019
+  #    imageTag: 2-windows-1809-alpha
+  #    buildNumber: 10.0.17763
+  #  - version: 2022
+  #    imageTag: 2-windows-ltsc2022-alpha
+  #    buildNumber: 10.0.20348
+  #  - version: 20h2
+  #    imageTag: 2-windows-20H2-alpha
+  #    buildNumber: 10.0.19042
   annotations: {}
   # -- Tolerations for the control plane DaemonSet.
   # @default -- Schedules in all tainted nodes

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -85,7 +85,8 @@ kubelet:
   enabled: true
   # -- Enable Windows monitoring and update `windowsOsList` with the list of Windows versions present in the cluster.
   enableWindows: false
-  # --  List of Windows versions present in the cluster. Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022
+  # -- `windowsOsList` is only required if `enableWindows` is true. It contains list of Windows versions present in the cluster.
+  # Our Kubernetes integration supported Windows versions LTSC 2019 (1809), 20H2, and LTSC 2022
   windowsOsList: []
   #  - version: 2019
   #    imageTag: 2-windows-1809-alpha


### PR DESCRIPTION
Updating helm charts to support version 3 windows integration

Testing : Tested in local EKS cluster with the following node config

```
kubectl get nodes -o wide
NAME                          STATUS   ROLES    AGE     VERSION                INTERNAL-IP   EXTERNAL-IP      OS-IMAGE                         KERNEL-VERSION                 CONTAINER-RUNTIME
ip-10-0-11-231.ec2.internal   Ready    <none>   3d21h   v1.23.17-eks-a59e1f0   10.0.11.231   18.208.247.135   Windows Server 2022 Datacenter   10.0.20348.1668                docker://20.10.21
ip-10-0-110-39.ec2.internal   Ready    <none>   22d     v1.23.17-eks-a59e1f0   10.0.110.39   <none>           Windows Server 2019 Datacenter   10.0.17763.4252                docker://20.10.21
ip-10-0-27-190.ec2.internal   Ready    <none>   22d     v1.23.17-eks-a59e1f0   10.0.27.190   3.95.250.93      Amazon Linux 2                   5.4.238-148.347.amzn2.x86_64   docker://20.10.17
```

Dashboard: https://onenr.io/0BQ18La75jx

Original PR (with comments): https://github.com/newrelic/nri-kubernetes/pull/744 