### PR TITLE
Update kubelet static testing exclusions.

### DIFF
--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -49,6 +49,11 @@ func TestScraper(t *testing.T) {
 				exclude.Groups("job_name"),
 				exclude.Optional(),
 			),
+			// Kubernetes pod can be created without the need of a deployment
+			exclude.Exclude(
+				exclude.Groups("pod"),
+				exclude.Optional(),
+			),
 			// Kubernetes deployment's `condition` attribute operate in a true-or-NULL basis, so it won't be present if false
 			exclude.Exclude(
 				exclude.Groups("deployment"),

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -178,12 +178,6 @@ func kubeletExclusions() []exclude.Func {
 			},
 		),
 
-		// Exclude metrics that are marked as optional.
-		exclude.Exclude(
-			exclude.Groups("container", "pod"),
-			exclude.Optional(),
-		),
-
 		// Exclude metrics that depend on limits when those limits are not set.
 		exclude.Exclude(exclude.Groups("pod", "container"), exclude.Dependent(utilizationDependencies)),
 
@@ -204,6 +198,42 @@ func kubeletExclusions() []exclude.Func {
 				return !asserter.EntityMetricIs(ent, "createdKind", "deployment")
 			},
 			exclude.Metrics("createdAt", "createdBy", "createdKind", "deploymentName"),
+		),
+
+		// Exclude daemonsetName metric for pods not created by a daemonset
+		exclude.Exclude(
+			exclude.Groups("pod", "container"),
+			func(_ string, _ *definition.Spec, ent *integration.Entity) bool {
+				return !asserter.EntityMetricIs(ent, "createdKind", "DaemonSet")
+			},
+			exclude.Metrics("createdAt", "createdBy", "createdKind", "daemonsetName"),
+		),
+
+		// Exclude jobName metric for pods not created by a job
+		exclude.Exclude(
+			exclude.Groups("pod", "container"),
+			func(_ string, _ *definition.Spec, ent *integration.Entity) bool {
+				return !asserter.EntityMetricIs(ent, "createdKind", "Job")
+			},
+			exclude.Metrics("createdAt", "createdBy", "createdKind", "jobName"),
+		),
+
+		// Exclude replicasetName metric for pods not created by a replicaset
+		exclude.Exclude(
+			exclude.Groups("pod", "container"),
+			func(_ string, _ *definition.Spec, ent *integration.Entity) bool {
+				return !asserter.EntityMetricIs(ent, "createdKind", "ReplicaSet")
+			},
+			exclude.Metrics("createdAt", "createdBy", "createdKind", "replicasetName"),
+		),
+
+		// Exclude statefulsetName metric for pods not created by a statefulset
+		exclude.Exclude(
+			exclude.Groups("pod", "container"),
+			func(_ string, _ *definition.Spec, ent *integration.Entity) bool {
+				return !asserter.EntityMetricIs(ent, "createdKind", "StatefulSet")
+			},
+			exclude.Metrics("createdAt", "createdBy", "createdKind", "statefulsetName"),
 		),
 
 		// Exclude metrics known to be missing for pods that are pending.

--- a/src/kubelet/kubelet_test.go
+++ b/src/kubelet/kubelet_test.go
@@ -195,7 +195,7 @@ func kubeletExclusions() []exclude.Func {
 		exclude.Exclude(
 			exclude.Groups("pod", "container"),
 			func(_ string, _ *definition.Spec, ent *integration.Entity) bool {
-				return !asserter.EntityMetricIs(ent, "createdKind", "deployment")
+				return !asserter.EntityMetricIs(ent, "createdKind", "Deployment")
 			},
 			exclude.Metrics("createdAt", "createdBy", "createdKind", "deploymentName"),
 		),


### PR DESCRIPTION
PR #733 updated the Kubelet tests to exclude all optional metrics.
This PR updates the Kubelet tests to more specifically exclude just the changes added in #733. 
