### PR TITLE
Silence log messages that mask testing errors

### DIFF
--- a/src/controlplane/controlplane_test.go
+++ b/src/controlplane/controlplane_test.go
@@ -51,6 +51,7 @@ func Test_Scraper_Autodiscover_all_cp_components(t *testing.T) {
 	controlPlaneSpecs["api-server"] = metric.APIServerSpecs["api-server"]
 
 	asserter := asserter.New().
+		Silently().
 		Using(controlPlaneSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
@@ -129,6 +130,7 @@ func Test_Scraper_Autodiscover_cp_component_after_start(t *testing.T) {
 	t.Parallel()
 
 	asserter := asserter.New().
+		Silently().
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,
@@ -198,6 +200,7 @@ func Test_Scraper_external_endpoint(t *testing.T) {
 	t.Parallel()
 
 	asserter := asserter.New().
+		Silently().
 		Using(metric.SchedulerSpecs).
 		Excluding(
 			ExcludeRenamedMetricsBasedOnLabels,

--- a/src/ksm/ksm_test.go
+++ b/src/ksm/ksm_test.go
@@ -31,6 +31,7 @@ func (nf NamespaceFilterMock) IsAllowed(namespace string) bool {
 func TestScraper(t *testing.T) {
 	// Create an asserter with the settings that are shared for all test scenarios.
 	asserter := asserter.New().
+		Silently().
 		Using(metric.KSMSpecs).
 		Excluding(
 			// Exclude service.loadBalancerIP unless service is e2e-lb (specially crafted to have a fake one)


### PR DESCRIPTION
Currently some but not all static tests output both log messages and errors when tests fail. This PR makes all tests only display error messages upon failure, so it is easier to identify missing metrics