### PR TITLE
chore(deps): Directly Use Prometheus Parser - remove prom2json dep 

### DIFF
--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -139,7 +139,6 @@ func parseResponse(resp *http.Response, ch chan<- *model.MetricFamily) error {
 
 	var parser expfmt.TextParser
 	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
-
 	if err != nil {
 		err = fmt.Errorf("reading text format failed: %w", err)
 	}

--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -132,7 +132,7 @@ func valueFromPrometheus(metricType model.MetricType, metric *model.Metric) Valu
  * Try our best to parse a response. Even if an error is encountered
  * midway through parsing we will put into the receiving channel any
  * metric families found along the way. We also return any error that
- * we did come along. Fail-fast, best attempt behaviour.
+ * we did come along. Fail-fast, best attempt behavior.
  */
 func parseResponse(resp *http.Response, ch chan<- *model.MetricFamily) error {
 	defer close(ch)
@@ -141,7 +141,7 @@ func parseResponse(resp *http.Response, ch chan<- *model.MetricFamily) error {
 	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
 
 	if err != nil {
-		err = fmt.Errorf("reading text format failed: %v", err)
+		err = fmt.Errorf("reading text format failed: %w", err)
 	}
 
 	for _, mf := range metricFamilies {

--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	model "github.com/prometheus/client_model/go"
-	"github.com/prometheus/prom2json"
+	"github.com/prometheus/common/expfmt"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/newrelic/nri-kubernetes/v3/src/client"
@@ -128,6 +128,29 @@ func valueFromPrometheus(metricType model.MetricType, metric *model.Metric) Valu
 	}
 }
 
+/**
+ * Try our best to parse a response. Even if an error is encounterd
+ * midway thorugh parsing we will put into the receiving channel any
+ * metric families found along the way. We also return any error that
+ * we did come along. Fail-fast, best attempt behaviour
+ */
+func parseResponse(resp *http.Response, ch chan<- *model.MetricFamily) error {
+	defer close(ch)
+
+	var parser expfmt.TextParser
+	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
+
+	if err != nil {
+		err = fmt.Errorf("reading text format failed: %v", err)
+	}
+
+	for _, mf := range metricFamilies {
+		ch <- mf
+	}
+
+	return err
+}
+
 func handleResponseWithFilter(resp *http.Response, queries []Query) ([]MetricFamily, error) {
 	if resp == nil {
 		return nil, fmt.Errorf("response cannot be nil")
@@ -144,7 +167,7 @@ func handleResponseWithFilter(resp *http.Response, queries []Query) ([]MetricFam
 
 	var err error
 	go func() {
-		err = prom2json.ParseResponse(resp, ch)
+		err = parseResponse(resp, ch)
 	}()
 
 	for promMetricFamily := range ch {

--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -129,8 +129,8 @@ func valueFromPrometheus(metricType model.MetricType, metric *model.Metric) Valu
 }
 
 /**
- * Try our best to parse a response. Even if an error is encounterd
- * midway thorugh parsing we will put into the receiving channel any
+ * Try our best to parse a response. Even if an error is encountered
+ * midway through parsing we will put into the receiving channel any
  * metric families found along the way. We also return any error that
  * we did come along. Fail-fast, best attempt behaviour
  */

--- a/src/prometheus/query.go
+++ b/src/prometheus/query.go
@@ -132,7 +132,7 @@ func valueFromPrometheus(metricType model.MetricType, metric *model.Metric) Valu
  * Try our best to parse a response. Even if an error is encountered
  * midway through parsing we will put into the receiving channel any
  * metric families found along the way. We also return any error that
- * we did come along. Fail-fast, best attempt behaviour
+ * we did come along. Fail-fast, best attempt behaviour.
  */
 func parseResponse(resp *http.Response, ch chan<- *model.MetricFamily) error {
 	defer close(ch)

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -248,7 +248,7 @@ func TestParseResponse(t *testing.T) {
 	}
 
 	// Parse response will keep filling the channel until
-	// it encounters some sort of error
+	// it encounters some sort of error.
 	assert.Equal(t, 1, oneFamilies)
 	assert.Equal(t, 0, twoFamilies)
 	assert.NotNil(t, errOne)

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -189,6 +189,7 @@ func TestQueryMatch_CustomName(t *testing.T) {
 	assert.Equal(t, expectedMetrics, q.Execute(&r))
 }
 
+//nolint:bodyclose
 func TestParseResponse(t *testing.T) {
 	t.Parallel()
 
@@ -226,6 +227,9 @@ func TestParseResponse(t *testing.T) {
 	responseOne := wOne.Result()
 	responseTwo := wTwo.Result()
 
+	defer responseOne.Body.Close()
+	defer responseTwo.Body.Close()
+
 	var errOne error
 	var errTwo error
 	go func() {
@@ -245,9 +249,6 @@ func TestParseResponse(t *testing.T) {
 		_ = mf
 		twoFamilies++
 	}
-
-	responseOne.Body.Close()
-	responseTwo.Body.Close()
 
 	// Parse response will keep filling the channel until
 	// it encounters some sort of error.

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -190,6 +190,8 @@ func TestQueryMatch_CustomName(t *testing.T) {
 }
 
 func TestParseResponse(t *testing.T) {
+	t.Parallel()
+
 	chOne := make(chan *model.MetricFamily)
 	chTwo := make(chan *model.MetricFamily)
 
@@ -220,16 +222,16 @@ func TestParseResponse(t *testing.T) {
 
 	handlerOne(wOne, req)
 	handlerTwo(wTwo, req)
-	respOne := wOne.Result()
-	respTwo := wTwo.Result()
+	responseOne := wOne.Result()
+	responseTwo := wTwo.Result()
 
 	var errOne error
 	var errTwo error
 	go func() {
-		errOne = parseResponse(respOne, chOne)
+		errOne = parseResponse(responseOne, chOne)
 	}()
 	go func() {
-		errTwo = parseResponse(respTwo, chTwo)
+		errTwo = parseResponse(responseTwo, chTwo)
 	}()
 
 	var oneFamilies int
@@ -244,7 +246,7 @@ func TestParseResponse(t *testing.T) {
 	}
 
 	// Parse response will keep filling the channel until
-	// it encouters some sort of error
+	// it encounters some sort of error
 	assert.Equal(t, 1, oneFamilies)
 	assert.Equal(t, 0, twoFamilies)
 	assert.NotNil(t, errOne)

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -246,8 +246,8 @@ func TestParseResponse(t *testing.T) {
 		twoFamilies++
 	}
 
-	defer responseOne.Body.Close()
-	defer responseTwo.Body.Close()
+	responseOne.Body.Close()
+	responseTwo.Body.Close()
 
 	// Parse response will keep filling the channel until
 	// it encounters some sort of error.

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -226,8 +226,8 @@ func TestParseResponse(t *testing.T) {
 	responseOne := wOne.Result()
 	responseTwo := wTwo.Result()
 
-	defer responseOne.Body.Close()
-	defer responseTwo.Body.Close()
+	defer responseOne.Body.Close() // nolint: errcheck
+	defer responseTwo.Body.Close() // nolint: errcheck
 
 	var errOne error
 	var errTwo error

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -226,9 +226,6 @@ func TestParseResponse(t *testing.T) {
 	responseOne := wOne.Result()
 	responseTwo := wTwo.Result()
 
-	defer responseOne.Body.Close() //nolint:bodyclose
-	defer responseTwo.Body.Close() //nolint:bodyclose
-
 	var errOne error
 	var errTwo error
 	go func() {
@@ -248,6 +245,9 @@ func TestParseResponse(t *testing.T) {
 		_ = mf
 		twoFamilies++
 	}
+
+	defer responseOne.Body.Close()
+	defer responseTwo.Body.Close()
 
 	// Parse response will keep filling the channel until
 	// it encounters some sort of error.

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -196,7 +196,7 @@ func TestParseResponse(t *testing.T) {
 	chTwo := make(chan *model.MetricFamily)
 
 	handlerOne := func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w,
+		_, err := io.WriteString(w,
 			`# HELP kube_pod_status_phase The pods current phase. 
 			 # TYPE kube_pod_status_phase gauge
 			 kube_pod_status_phase{namespace="default",pod="123456789"} 1
@@ -204,9 +204,10 @@ func TestParseResponse(t *testing.T) {
 			 # TYPE kube_custom_elasticsearch_health_status stateset
 			 kube_custom_elasticsearch_health_status {customresource_group="elasticsearch.k8s.elastic.co"} 1
 			`)
+		assert.NotNil(t, err)
 	}
 	handlerTwo := func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w,
+		_, err := io.WriteString(w,
 			`# HELP kube_custom_elasticsearch_health_status Elasticsearch CRD health status
 			 # TYPE kube_custom_elasticsearch_health_status stateset
 			 kube_custom_elasticsearch_health_status {customresource_group="elasticsearch.k8s.elastic.co"} 1
@@ -214,6 +215,7 @@ func TestParseResponse(t *testing.T) {
 			 # TYPE kube_pod_status_phase gauge
 			 kube_pod_status_phase{namespace="default",pod="123456789"} 1
 			`)
+		assert.NotNil(t, err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -226,8 +226,8 @@ func TestParseResponse(t *testing.T) {
 	responseOne := wOne.Result()
 	responseTwo := wTwo.Result()
 
-	defer responseOne.Body.Close() //nolint: errcheck
-	defer responseTwo.Body.Close() //nolint: errcheck
+	defer responseOne.Body.Close() //nolint
+	defer responseTwo.Body.Close() //nolint
 
 	var errOne error
 	var errTwo error

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -204,7 +204,7 @@ func TestParseResponse(t *testing.T) {
 			 # TYPE kube_custom_elasticsearch_health_status stateset
 			 kube_custom_elasticsearch_health_status {customresource_group="elasticsearch.k8s.elastic.co"} 1
 			`)
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
 	}
 	handlerTwo := func(w http.ResponseWriter, r *http.Request) {
 		_, err := io.WriteString(w,
@@ -215,7 +215,7 @@ func TestParseResponse(t *testing.T) {
 			 # TYPE kube_pod_status_phase gauge
 			 kube_pod_status_phase{namespace="default",pod="123456789"} 1
 			`)
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -226,8 +226,8 @@ func TestParseResponse(t *testing.T) {
 	responseOne := wOne.Result()
 	responseTwo := wTwo.Result()
 
-	defer responseOne.Body.Close() // nolint: errcheck
-	defer responseTwo.Body.Close() // nolint: errcheck
+	defer responseOne.Body.Close() //nolint: errcheck
+	defer responseTwo.Body.Close() //nolint: errcheck
 
 	var errOne error
 	var errTwo error

--- a/src/prometheus/query_test.go
+++ b/src/prometheus/query_test.go
@@ -226,8 +226,8 @@ func TestParseResponse(t *testing.T) {
 	responseOne := wOne.Result()
 	responseTwo := wTwo.Result()
 
-	defer responseOne.Body.Close() //nolint
-	defer responseTwo.Body.Close() //nolint
+	defer responseOne.Body.Close() //nolint:bodyclose
+	defer responseTwo.Body.Close() //nolint:bodyclose
 
 	var errOne error
 	var errTwo error


### PR DESCRIPTION
Using prom2Json results in the implicit loss of all metric families when any error is encountered while reading the prometheus exposition format. 

This change is a sort of POC to show that by directly using the parser provided by the prometheus library, we the callers can choose what to do with some of the seen metrics before an error was encountered while parsing. 

None of the functionality of the scrapers were changed and they remain semantically the same. 

A test was added to show how `parseResponse` preserves metric families that are seen even when parsing errors are encountered. The behaviour is to only keep the metrics seen up until the time of failure

I have successfully run the e2e tests locally and through the github actions here. 

## Testing 
Added new unit/feature tests and locally, successfully ran e2e tests