### PR TITLE
chore: Update CHANGELOG format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+### ⛓️ Dependencies
+
+### 🐞 Bug fixes
+
+### 🛡️ Security notices
+
+### 💥 Breaking changes
+
+### 🚀 Enhancements
 
 ## 3.15.3
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### ⛓️ Dependencies
-
-### 🐞 Bug fixes
-
-### 🛡️ Security notices
-
-### 💥 Breaking changes
-
-### 🚀 Enhancements
-
 ## 3.15.3
 ## What's Changed
 * bump app and chart version by @csongnr in https://github.com/newrelic/nri-kubernetes/pull/819

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,13 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-3. Add an entry to the CHANGELOG under the `Unreleased` section under an L3 header that specifies the type of your PR. If there is no L3 header for your type of PR, add a new L3 header. Here's an example of how it should look:
-  ```md
-    ## Unreleased
+3. Add an entry as an unordered list to the CHANGELOG under the `Unreleased` section under an L3 header that specifies the type of your PR. If there is no L3 header for your type of PR already in the Unreleased section, add a new L3 header. Here's an example of how it should look:
+    ```md
+      ## Unreleased
 
-    ### bugfix
-    - Fix some bug in some file
-  ```
+      ### bugfix
+      - Fix some bug in some file
+    ```
 
   - Here are the accepted L3 headers (case sensitive)
     + `breaking`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,21 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+3. Add an entry to the CHANGELOG under the `Unreleased` section under an L3 header that specifies the type of your PR. If there is no L3 header for your type of PR, add a new L3 header. Here's an example of how it should look:
+  ```md
+    ## Unreleased
+
+    ### bugfix
+    - Fix some bug in some file
+  ```
+
+  - Here are the accepted L3 headers (case sensitive)
+    + `breaking`
+    + `security`
+    + `enhancement`
+    + `bugfix`
+    + `dependency`
+
 3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Contributor License Agreement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Before submitting an Issue, please search for similar ones in the
     + `bugfix`
     + `dependency`
 
-3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Before submitting an Issue, please search for similar ones in the
     + `bugfix`
     + `dependency`
 
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+4. You may merge the Pull Request in once you have the sign-off of one other developer, or if you do not have permission to do that, you may request the other reviewer to merge it for you.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
In order to use the release toolkit, we need to follow a certain changelog format: https://github.com/newrelic/release-toolkit/blob/main/generate-yaml/README.md

This PR updates the changelog format. 