### PR TITLE
chore: Add CHANGELOG github workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,5 @@
 # This action requires that any PR targeting the main branch should touch at
-# least one CHANGELOG file. If a CHANGELOG entry is not required, add the "Skip
-# Changelog" label to disable this action.
+# least one CHANGELOG file.
 
 name: changelog
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,3 +18,4 @@ jobs:
 
       - name: Check if CHANGELOG is valid
         uses: newrelic/release-toolkit/validate-markdown@v1
+        

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,40 +10,11 @@ on:
     branches:
       - main
 jobs:
-  changelog:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Check for CHANGELOG file changes
-        run: |
-          # Only the latest commit of the feature branch is available
-          # automatically. To diff with the base branch, we need to
-          # fetch that too (and we only need its latest commit).
-          git fetch origin ${{ github.base_ref }} --depth=1
-          if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
-          then
-            echo "The CHANGELOG file was modified. Looks good!"
-          else
-            echo "The CHANGELOG file was not modified."
-            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\" , or add the \"Skip Changelog\" label if not required."
-            false
-          fi
-
   lint-changelog:
     runs-on: ubuntu-latest
-    needs: changelog
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Check for unordered list in changelog
-        run: |
-          if grep -E "^\s*-\s" ./CHANGELOG.md; then
-            echo "Changelog is valid: Unordered list items found."
-          else
-            echo "Changelog is invalid: No unordered list items found."
-            exit 1
-          fi
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,49 @@
+# This action requires that any PR targeting the main branch should touch at
+# least one CHANGELOG file. If a CHANGELOG entry is not required, add the "Skip
+# Changelog" label to disable this action.
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check for CHANGELOG file changes
+        run: |
+          # Only the latest commit of the feature branch is available
+          # automatically. To diff with the base branch, we need to
+          # fetch that too (and we only need its latest commit).
+          git fetch origin ${{ github.base_ref }} --depth=1
+          if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
+          then
+            echo "The CHANGELOG file was modified. Looks good!"
+          else
+            echo "The CHANGELOG file was not modified."
+            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\" , or add the \"Skip Changelog\" label if not required."
+            false
+          fi
+
+  lint-changelog:
+    runs-on: ubuntu-latest
+    needs: changelog
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check for unordered list in changelog
+        run: |
+          if grep -E "^\s*-\s" ./CHANGELOG.md; then
+            echo "Changelog is valid: Unordered list items found."
+          else
+            echo "Changelog is invalid: No unordered list items found."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancement
+- Add changelog workflow
+
 ## 3.15.3
 ## What's Changed
 * bump app and chart version by @csongnr in https://github.com/newrelic/nri-kubernetes/pull/819

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### enhancement
-- Add changelog workflow
+- Add changelog workflow by @svetlanabrennan in [#837](https://github.com/newrelic/nri-kubernetes/pull/837)
 
 ## 3.15.3
 ## What's Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-3. Add an entry to `CHANGELOG.md` under an appropiate L3 header like "### Bug fixes" under the "## Unreleased" L2 header.
+3. Add an entry to `CHANGELOG.md` under an appropriate L3 header like "### Bug fixes" under the "## Unreleased" L2 header.
   -  If a change does not require a changelog entry, add a "Skip Changelog" label to the pr. 
   - Pull requests with the "dependencies" label will be skipped by the changelog CI check.
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,10 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+3. Add an entry to `CHANGELOG.md` under an appropiate L3 header like "### Bug fixes" under the "## Unreleased" L2 header.
+  -  If a change does not require a changelog entry, add a "Skip Changelog" label to the pr. 
+  - Pull requests with the "dependencies" label will be skipped by the changelog CI check.
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,7 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-3. Add an entry to `CHANGELOG.md` under an appropriate L3 header like "### Bug fixes" under the "## Unreleased" L2 header.
-  -  If a change does not require a changelog entry, add a "Skip Changelog" label to the pr. 
-  - Pull requests with the "dependencies" label will be skipped by the changelog CI check.
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
Adding a changelog action that valids if a PR updates a changelog by using the `newrelic/release-toolkit/validate-markdown@v1`.

Relates to this PR: https://github.com/newrelic/nri-kubernetes/pull/836