### PR TITLE
fix: Use a stable metric instead of an experimental one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update Helm chart lint job by @juanjjaramillo in [#869](https://github.com/newrelic/nri-kubernetes/pull/869)
 - Update cpuLimitCores metric not available log to debug level in [#870](https://github.com/newrelic/nri-kubernetes/pull/870)
 
+### bugfix
+- Use a KSM stable metric instead of an experimental one by @juanjjaramillo in [#872](https://github.com/newrelic/nri-kubernetes/pull/872)
+
 ## 3.16.0
 ## What's Changed
 - Add changelog workflow by @svetlanabrennan in [#837](https://github.com/newrelic/nri-kubernetes/pull/837)

--- a/src/metric/definition.go
+++ b/src/metric/definition.go
@@ -920,9 +920,9 @@ var KSMSpecs = definition.SpecGroups{
 		},
 	},
 	"horizontalpodautoscaler": {
-		IDGenerator: prometheus.FromLabelValueEntityIDGenerator("kube_horizontalpodautoscaler_info", "horizontalpodautoscaler"),
+		IDGenerator: prometheus.FromLabelValueEntityIDGenerator("kube_horizontalpodautoscaler_status_current_replicas", "horizontalpodautoscaler"),
 		// group customized for backwards compatibility reasons (Metrics where renamed in KSM v2)
-		TypeGenerator:   prometheus.FromLabelValueEntityTypeGeneratorWithCustomGroup("kube_horizontalpodautoscaler_info", "hpa"),
+		TypeGenerator:   prometheus.FromLabelValueEntityTypeGeneratorWithCustomGroup("kube_horizontalpodautoscaler_status_current_replicas", "hpa"),
 		NamespaceGetter: prometheus.FromLabelGetNamespace,
 		MsTypeGuesser:   metricSetTypeGuesserWithCustomGroup("hpa"), // group customized for backwards compatibility reasons
 		Specs: []definition.Spec{


### PR DESCRIPTION
## Which problem is this PR solving?

In #867 we used an experimental metric to generate the HPA ID and type. This PR uses instead a stable metric.

## Short description of the changes

Scraping stable metrics is a better approach than using experimental metrics that can change without notice.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)