### PR TITLE
ci: Update minikube version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.9.0
         with:
-          minikube version: v1.30.1
+          minikube version: v1.31.2
           kubernetes version: ${{ matrix.k8sVersion }}
           driver: docker
           start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.9.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.31.1
+          minikube version: v1.31.2
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v4


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Updating minikube version so Helm chart linting works for Kubernetes v 1.27
## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  