### PR TITLE
feat: enable granular config of container resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancement
+- Add granular resource config for kubelet in [#918](https://github.com/newrelic/nri-kubernetes/pull/918)
+
+
 ## v3.18.3 - 2023-10-23
 
 ### ⛓️ Dependencies

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -203,7 +203,7 @@ spec:
             {{- with .Values.kubelet.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.kubelet.resources }}
+          {{- with .Values.kubelet.agent.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
       volumes:

--- a/charts/newrelic-infrastructure/tests/resources_kubelet_test.yaml
+++ b/charts/newrelic-infrastructure/tests/resources_kubelet_test.yaml
@@ -1,0 +1,66 @@
+suite: test resources for kubelet
+templates:
+  - kubelet/daemonset.yaml
+tests:
+  - it: kubelet container uses default resources
+    set:
+      cluster: test
+      licenseKey: test
+    asserts:
+      - template: kubelet/daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 150M
+            limits:
+              memory: 300M
+  - it: agent container uses default resources
+    set:
+      cluster: test
+      licenseKey: test
+    asserts:
+      - template: kubelet/daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[1].resources
+          value:
+            requests:
+              cpu: 100m
+              memory: 150M
+            limits:
+              memory: 300M
+  - it: kubelet container uses modified resources
+    set:
+      cluster: test
+      licenseKey: test
+      kubelet.resources.requests.cpu: 123m
+      kubelet.resources.requests.memory: 234Mi
+      kubelet.resources.limits.memory: 345Mi
+    asserts:
+      - template: kubelet/daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources
+          value:
+            requests:
+              cpu: 123m
+              memory: 234Mi
+            limits:
+              memory: 345Mi
+  - it: agent container uses modified resources
+    set:
+      cluster: test
+      licenseKey: test
+      kubelet.agent.resources.requests.cpu: 12m
+      kubelet.agent.resources.requests.memory: 23Mi
+      kubelet.agent.resources.limits.memory: 34Mi
+    asserts:
+      - template: kubelet/daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[1].resources
+          value:
+            requests:
+              cpu: 12m
+              memory: 23Mi
+            limits:
+              memory: 34Mi

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -130,6 +130,13 @@ kubelet:
     scraperMaxReruns: 4
   # port:
   # scheme:
+  agent:
+    resources:
+      limits:
+        memory: 300M
+      requests:
+        cpu: 100m
+        memory: 150M
 
 # ksm -- Configuration for the Deployment that collects state metrics from KSM (kube-state-metrics).
 # @default -- See `values.yaml`


### PR DESCRIPTION
## Description
Allows for granular config of container resources on the kubelet.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [x] This change requires changes in testing:
  - [x] unit tests
  - [ ] E2E tests
  