### PR TITLE
feat(kubelet): Create an agent container in the kubelet pod only

### DIFF
--- a/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_naming.tpl
@@ -1,6 +1,10 @@
 {{- /* Naming helpers*/ -}}
 {{- define "nriKubernetes.kubelet.fullname" -}}
+{{- if (.Values.kubelet.agentOnly) }}
+{{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "agent") -}}
+{{- else }}
 {{- include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "nriKubernetes.naming.fullname" .) "suffix" "kubelet") -}}
+{{- end }}
 {{- end -}}
 
 {{- define "nriKubernetes.kubelet.fullname.agent" -}}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -28,7 +28,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if not (.Values.kubelet.agentOnly) }}
         checksum/nri-kubernetes: {{ include (print $.Template.BasePath "/kubelet/scraper-configmap.yaml") . | sha256sum }}
+        {{- end }}
         checksum/agent-config: {{ include (print $.Template.BasePath "/kubelet/agent-configmap.yaml") . | sha256sum }}
         {{- if include "newrelic.common.license.secret" . }}{{- /* If the is secret to template */}}
         checksum/license-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -239,12 +241,14 @@ spec:
           emptyDir: {}
         - name: agent-tmpfs-tmp
           emptyDir: {}
+        {{- if not (.Values.kubelet.agentOnly) }}
         - name: nri-kubernetes-config
           configMap:
             name: {{ include "nriKubernetes.kubelet.fullname" . }}
             items:
               - key: nri-kubernetes.yml
                 path: nri-kubernetes.yml
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "nriKubernetes.kubelet.fullname.agent" . }}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
       initContainers: {{- tpl (.Values.kubelet.initContainers | toYaml) . | nindent 8 }}
       {{- end }}
       containers:
+        {{- if not (.Values.kubelet.agentOnly) }}
         - name: kubelet
           image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.images.integration "context" .) }}
           imagePullPolicy: {{ .Values.images.integration.pullPolicy }}
@@ -102,6 +103,7 @@ spec:
           {{- with .Values.kubelet.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
         - name: agent
           image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.images.agent "context" .) }}
           args: [ "newrelic-infra" ]

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if (.Values.kubelet.enabled) }}
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ if (.Values.kubelet.agentOnly) }}Deployment{{ else }}DaemonSet{{ end }}
 metadata:
   namespace: {{ .Release.Namespace }}
   labels:
@@ -11,8 +11,15 @@ metadata:
   annotations: {{ . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if (.Values.kubelet.agentOnly) }}
+  {{- with .Values.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if not (.Values.kubelet.agentOnly) }}
   {{- with .Values.updateStrategy }}
   updateStrategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/newrelic-infrastructure/templates/kubelet/scraper-configmap.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/scraper-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubelet.enabled -}}
+{{- if and (.Values.kubelet.enabled) (not (.Values.kubelet.agentOnly)) -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -83,6 +83,9 @@ kubelet:
   # -- Enable kubelet monitoring.
   # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
+  # -- Enable agent only.
+  # Advanced users only. Setting this to `true` is not supported and will break the New Relic experience.
+  # deploy only an agent container from a deployment rather than agent and kubelet containers from a daemonSet
   agentOnly: false
   annotations: {}
   # -- Tolerations for the control plane DaemonSet.

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -83,6 +83,7 @@ kubelet:
   # -- Enable kubelet monitoring.
   # Advanced users only. Setting this to `false` is not supported and will break the New Relic experience.
   enabled: true
+  agentOnly: false
   annotations: {}
   # -- Tolerations for the control plane DaemonSet.
   # @default -- Schedules in all tainted nodes


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
This provides the user with the ability to create only a single pod containing an infrastructure agent container when combined with `kubelet.enabled == false` and `ksm.enabled == false`.

This is useful when you already have your kubernetes infrastructure monitored by newrelic at the infrastructure layer and you want to retrieve the length of some redis keys which are relevant at the application layer.

For more details of the motivation for this change please see #943

Fixes: #943 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  
I tested this locally and everything works as it ought to
```
$ helm install -n newrelic-infrastructure tormod ./newrelic-infrastructure/ --set ksm.enabled=false --set controlPlane.enabled=false --set kubelet.agentOnly=false

$ kubectl -n newrelic-infrastructure get all
NAME                             READY   STATUS    RESTARTS   AGE
pod/tormod-nrk8s-kubelet-fblcd   2/2     Running   0          19s
pod/tormod-nrk8s-kubelet-fjn45   2/2     Running   0          19s

NAME                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/tormod-nrk8s-kubelet   2         2         2       2            2           <none>          20s

$ kubectl -n newrelic-infrastructure get configmaps
NAME                            DATA   AGE
kube-root-ca.crt                1      22h
tormod-nrk8s-agent-kubelet      1      44s
tormod-nrk8s-integrations-cfg   1      44s
tormod-nrk8s-kubelet            1      44s

$ helm uninstall -n newrelic-infrastructure tormod
release "tormod" uninstalled
```
```
$ helm install -n newrelic-infrastructure tormod ./newrelic-infrastructure/ --set ksm.enabled=false --set controlPlane.enabled=false --set kubelet.agentOnly=true

$ kubectl -n newrelic-infrastructure get all
NAME                                      READY   STATUS    RESTARTS   AGE
pod/tormod-nrk8s-agent-7bdd794558-2c9zq   1/1     Running   0          18s

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/tormod-nrk8s-agent   1/1     1            1           18s

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/tormod-nrk8s-agent-7bdd794558   1         1         1       18s

$ kubectl -n newrelic-infrastructure get configmaps
NAME                            DATA   AGE
kube-root-ca.crt                1      22h
tormod-nrk8s-agent-kubelet      1      48s
tormod-nrk8s-integrations-cfg   1      48s

$ helm uninstall -n newrelic-infrastructure tormod
release "tormod" uninstalled
```