### PR TITLE
Add quotes to "true" value so it is not interpreted as a boolean

### DIFF
--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -53,7 +53,7 @@ common:
     namespaceSelector: {}
     # If you want to include only namespaces with a given label you could do so by adding:
     # matchLabels:
-    #   newrelic.com/scrape: true
+    #   newrelic.com/scrape: "true"
     # Otherwise you can build more complex filters and include or exclude certain namespaces by adding one or multiple
     # expressions that are added, for instance:
     # matchExpressions:


### PR DESCRIPTION
## Description
The scrape label for namespaces is documented in values with a commented example. This example will not run as-is and results in the newrelic-infrastructure pods crashing on startup.

`newrelic.com/scrape: true`

This change adds quotes (") to the example. Tested working on a fresh installation.

`newrelic.com/scrape: "true"`

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  