### PR TITLE
fix: pin mountPropagation of host fs in privileged mode (NR-274598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### bugfix
 - Fix expired certificated @dbudziwojskiNR [#1064](https://github.com/newrelic/nri-kubernetes/pull/1064)
+- Fix StorageSample.DiskCapacity metric badly report for devices mounted after the kubelet pod started [#1066](https://github.com/newrelic/nri-kubernetes/pull/1066/files)
 
 ## v3.28.8 - 2024-05-27
 

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -192,6 +192,7 @@ spec:
               mountPath: /var/log
             - name: host-volume
               mountPath: /host
+              mountPropagation: HostToContainer
               readOnly: true
             {{- end }}
             - mountPath: /var/db/newrelic-infra/data


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

Infrastructure Agent captures Storage Samples of underlying nodes based on the mounted file system. Whenever a new pvc is mounted on the host, this mount needs to be propagated (`rslave`)to the mounted filesystem in the agent container. 

By default k8s uses `none` as mount propagation, and according to [k8s docs](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation) depends on the CRI which propagation is used `rprivate` or in some cases like docker `rslave`. 

This PR configures the host file system volume to be mounted with `rslave` independently of the CRI. This fixes some miss behaving storage metrics samples where the device disk space of a newly mounted device has the value of the primary host storage ( and the issue was fixed upon Pod recreation)


## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  