### PR TITLE
fix: The master node-role was removed in Kube 1.24

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Troubleshooting
-    url:  https://github.com/newrelic/nri-kubernetes/blob/master/README.md#support
+    url:  https://github.com/newrelic/nri-kubernetes/blob/main/README.md#support
     about: Check out the README for troubleshooting directions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v3.30.1 - 2024-10-22
+
+### 🐞 Bug fixes
+- Remove node-role.kubernetes.io/master as a control plane selector since it was removed in Kube 1.24 and now causes warnings in 1.31 @zzeitlerc [#1118](https://github.com/newrelic/nri-kubernetes/pull/1118)
+
 ## v3.30.0 - 2024-10-15
 
 ### 🚀 Enhancements
 - Add 1.31 support and drop 1.26 @zeitlerc [#1114](https://github.com/newrelic/nri-kubernetes/pull/1114)
-
 
 ## v3.29.6 - 2024-10-07
 

--- a/charts/newrelic-infrastructure/README.md
+++ b/charts/newrelic-infrastructure/README.md
@@ -74,7 +74,7 @@ fallbacks to `affinity` (at root level), and if that value is empty, the chart f
 
 The same procedure applies to `nodeSelector` and `tolerations`.
 
-On the other hand, some components have affinities and tolerations predefined e.g. to be able to run kubelet pods on nodes that are tainted as master
+On the other hand, some components have affinities and tolerations predefined e.g. to be able to run kubelet pods on nodes that are tainted as control plane
 nodes or to schedule the KSM scraper on the same node of KSM to reduce the inter-node traffic.
 
 If you are having problems assigning pods to nodes it may be because of this. Take a look at the [`values.yaml`](values.yaml) to see if the pod that is
@@ -115,7 +115,7 @@ integrations that you have configured.
 | common.config.namespaceSelector | object | `{}` | Config for filtering ksm and kubelet metrics by namespace. |
 | containerSecurityContext | object | `{}` | Sets security context (at container level). Can be configured also with `global.containerSecurityContext` |
 | controlPlane | object | See `values.yaml` | Configuration for the control plane scraper. |
-| controlPlane.affinity | object | Deployed only in master nodes. | Affinity for the control plane DaemonSet. |
+| controlPlane.affinity | object | Deployed only in control plane nodes. | Affinity for the control plane DaemonSet. |
 | controlPlane.agentConfig | object | `{}` | Config for the Infrastructure agent that will forward the metrics to the backend. It will be merged with the configuration in `.common.agentConfig` See: https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/ |
 | controlPlane.config.apiServer | object | Common settings for most K8s distributions. | API Server monitoring configuration |
 | controlPlane.config.apiServer.enabled | bool | `true` | Enable API Server monitoring |

--- a/charts/newrelic-infrastructure/README.md.gotmpl
+++ b/charts/newrelic-infrastructure/README.md.gotmpl
@@ -71,7 +71,7 @@ fallbacks to `affinity` (at root level), and if that value is empty, the chart f
 
 The same procedure applies to `nodeSelector` and `tolerations`.
 
-On the other hand, some components have affinities and tolerations predefined e.g. to be able to run kubelet pods on nodes that are tainted as master
+On the other hand, some components have affinities and tolerations predefined e.g. to be able to run kubelet pods on nodes that are tainted as control plane
 nodes or to schedule the KSM scraper on the same node of KSM to reduce the inter-node traffic.
 
 If you are having problems assigning pods to nodes it may be because of this. Take a look at the [`values.yaml`](values.yaml) to see if the pod that is

--- a/charts/newrelic-infrastructure/tests/affinity_controlPlane_test.yaml
+++ b/charts/newrelic-infrastructure/tests/affinity_controlPlane_test.yaml
@@ -6,7 +6,7 @@ templates:
   - templates/agent-configmap.yaml
   - templates/secret.yaml
 tests:
-  - it: empty affinity defaults to master nodes
+  - it: empty affinity defaults to control plane nodes
     set:
       licenseKey: test
       cluster: test
@@ -29,9 +29,6 @@ tests:
                         operator: Exists
                   - matchExpressions:
                       - key: node-role.kubernetes.io/etcd
-                        operator: Exists
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/master
                         operator: Exists
         template: templates/controlplane/daemonset.yaml
 
@@ -91,9 +88,6 @@ tests:
                         operator: Exists
                   - matchExpressions:
                       - key: node-role.kubernetes.io/etcd
-                        operator: Exists
-                  - matchExpressions:
-                      - key: node-role.kubernetes.io/master
                         operator: Exists
         template: templates/controlplane/daemonset.yaml
 

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -210,7 +210,7 @@ controlPlane:
       effect: "NoExecute"
   nodeSelector: {}
   # -- Affinity for the control plane DaemonSet.
-  # @default -- Deployed only in master nodes.
+  # @default -- Deployed only in control plane nodes.
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -223,9 +223,6 @@ controlPlane:
                 operator: Exists
           - matchExpressions:
               - key: node-role.kubernetes.io/etcd
-                operator: Exists
-          - matchExpressions:
-              - key: node-role.kubernetes.io/master
                 operator: Exists
   # -- How to deploy the control plane scraper. If autodiscovery is in use, it should be `DaemonSet`.
   # Advanced users using static endpoints set this to `Deployment` to avoid reporting metrics twice.

--- a/src/kubelet/grouper/group_test.go
+++ b/src/kubelet/grouper/group_test.go
@@ -127,7 +127,7 @@ func getNode() *v1.Node {
 				"kubernetes.io/arch":             "amd64",
 				"kubernetes.io/hostname":         "minikube",
 				"kubernetes.io/os":               "linux",
-				"node-role.kubernetes.io/master": "",
+				"node-role.kubernetes.io/control-plane": "",
 			},
 		},
 		Spec: v1.NodeSpec{

--- a/src/kubelet/metric/testdata/kubelet_group_expected.go
+++ b/src/kubelet/metric/testdata/kubelet_group_expected.go
@@ -290,7 +290,7 @@ var ExpectedGroupData = definition.RawGroups{
 				"kubernetes.io/arch":             "amd64",
 				"kubernetes.io/hostname":         "minikube",
 				"kubernetes.io/os":               "linux",
-				"node-role.kubernetes.io/master": "",
+				"node-role.kubernetes.io/control-plane": "",
 			},
 			"cpuRequestedCores": int64(501),
 			"allocatable": v1.ResourceList{


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

`node-role.kubernetes.io/master` was [removed in Kube 1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes) so we shouldn't need to select for it.  `node-role.kubernetes.io/control-plane` was added in Kube 1.20 as the replacement and should be used going forward.  [A deprecation warning](https://github.com/kubernetes/kubernetes/blob/81ce66f059ec9c07cccf4069c8913e31959dea78/pkg/api/node/util.go#L36) was added in Kube 1.31 which causes [open-install-library](https://github.com/newrelic/open-install-library) to fail install if we include that label in the selectors.

This is a breaking change for Kube less than 1.20, which we do not officially support.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Documentation has been updated
- [x] This change requires changes in testing:
  - [x] unit tests
  - [x] E2E tests
  