### PR TITLE
Splitting the kubelet containers resource values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## v3.33.0 - 2024-11-20
+
+### 🚀 Enhancements
+
+- Updating the kubelet daemonset to allow consumers to specify different resource limits for each container in the pod.
+
+### 🚀 Enhancements
 ## v3.32.0 - 2024-11-18
 
 ### 🚀 Enhancements

--- a/charts/newrelic-infrastructure/Chart.yaml
+++ b/charts/newrelic-infrastructure/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure
   - https://github.com/newrelic/infrastructure-agent/
 version: 3.37.0
-appVersion: 3.32.0
+appVersion: 3.33.0
 dependencies:
   - name: common-library
     version: 1.3.0

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -99,7 +99,7 @@ spec:
             {{- with .Values.kubelet.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.kubelet.resources }}
+          {{- with .Values.kubelet.resources.kubelet }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: agent
@@ -204,7 +204,7 @@ spec:
             {{- with .Values.kubelet.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.kubelet.resources }}
+          {{- with .Values.kubelet.resources.agent }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
       volumes:

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -116,11 +116,18 @@ kubelet:
   extraVolumeMounts: []
   initContainers: []
   resources:
-    limits:
-      memory: 300M
-    requests:
-      cpu: 100m
-      memory: 150M
+    kubelet:
+      limits:
+        memory: 300M
+      requests:
+        cpu: 100m
+        memory: 150M
+    agent:
+      limits:
+        memory: 300M
+      requests:
+        cpu: 100m
+        memory: 150M
   config:
     # -- Timeout for the kubelet APIs contacted by the integration
     timeout: 10s


### PR DESCRIPTION
## Description

Customers have reached out with a desire to specify a different cpu/memory for the kubelet container vs the agent container. As they feel like there's unused resources.

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  