### PR TITLE
feat: Build Windows images

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         goos: [ linux ]
         goarch: [ amd64, arm64, arm ]
-      include:
-        - goos: windows
-          goarch: amd64
+        include:
+          - goos: windows
+            goarch: amd64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -56,13 +56,13 @@ jobs:
       - name: Docker Build
         run: |
           docker build --file Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} -t nri-kubernetes:windows-${{ matrix.baseImageTag }} .
-          docker save nri-kubernetes:windows-${{ matrix.baseImageTag }} > /tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar
+          docker save nri-kubernetes:windows-${{ matrix.baseImageTag }} > nri-kubernetes-${{ matrix.baseImageTag }}.tar
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: nri-kubernetes-${{ matrix.baseImageTag }}
-          path: /tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar
+          path: nri-kubernetes-${{ matrix.baseImageTag }}.tar
 
   chart-lint:
     name: Helm chart Lint

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -44,9 +44,9 @@ jobs:
       matrix:
         include:
           - runsOn: windows-2019
-            baseImageTag: ltsc-2019-amd64
+            baseImageTag: ltsc2019-amd64
           - runsOn: windows-2022
-            baseImageTag: ltsc-2022-amd64
+            baseImageTag: ltsc2022-amd64
     runs-on: ${{ matrix.runsOn }}
     steps:
       - name: Download all artifacts from build job
@@ -55,7 +55,7 @@ jobs:
           path: bin
       - name: Docker Build
         run: |
-          docker buildx build -f Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} --output type=tar,dest=/tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar .
+          docker buildx build --file Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} --output type=tar,dest=/tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar .
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         goos: [ linux ]
         goarch: [ amd64, arm64, arm ]
+      include:
+        - goos: windows
+          goarch: amd64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -27,6 +30,38 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           make compile
+      - name: Upload artifact for docker build step
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          name: nri-kubernetes-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: bin/nri-kubernetes-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  docker-windows:
+    name: Docker image for
+    needs: [ build ]
+    strategy:
+      matrix:
+        include:
+          - runsOn: windows-2019
+            baseImageTag: ltsc-2019-amd64
+          - runsOn: windows-2022
+            baseImageTag: ltsc-2022-amd64
+    runs-on: ${{ matrix.runsOn }}
+    steps:
+      - name: Download all artifacts from build job
+        uses: actions/download-artifact@v4
+        with:
+          path: bin
+      - name: Docker Build
+        run: |
+          docker buildx build -f Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} --output type=tar,dest=/tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar .
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nri-kubernetes-${{ matrix.baseImageTag }}
+          path: /tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar
 
   chart-lint:
     name: Helm chart Lint

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -55,7 +55,7 @@ jobs:
           path: bin
       - name: Docker Build
         run: |
-          docker buildx build --file Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} --output type=tar,dest=/tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar .
+          docker build --file Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} --output type=tar,dest=/tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar .
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -55,7 +55,8 @@ jobs:
           path: bin
       - name: Docker Build
         run: |
-          docker build --file Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} --output type=tar,dest=/tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar .
+          docker build --file Dockerfile.windows --build-arg BASE_IMAGE_TAG=${{ matrix.baseImageTag }} -t nri-kubernetes:windows-${{ matrix.baseImageTag }} .
+          docker save nri-kubernetes:windows-${{ matrix.baseImageTag }} > /tmp/nri-kubernetes-${{ matrix.baseImageTag }}.tar
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -49,6 +49,7 @@ jobs:
             baseImageTag: ltsc2022-amd64
     runs-on: ${{ matrix.runsOn }}
     steps:
+      - uses: actions/checkout@v4
       - name: Download all artifacts from build job
         uses: actions/download-artifact@v4
         with:

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_TAG
+ARG BASE_IMAGE_TAG=ltsc2019-amd64
 FROM mcr.microsoft.com/windows/servercore:$BASE_IMAGE_TAG
 
 COPY bin/nri-kubernetes-windows-amd64 /bin/nri-kubernetes.exe

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE_TAG
+FROM mcr.microsoft.com/windows/servercore:$BASE_IMAGE_TAG
+
+COPY bin/nri-kubernetes-windows-amd64 /bin/nri-kubernetes.exe
+
+ENTRYPOINT ["/bin/nri-kubernetes.exe"]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
**Draft:** Currently only builds an image and saves it as an artifact so that the image can be downloaded from Github Actions for testing.  The image is not published to Dockerhub

Builds nri-kubernetes into a Windows docker container.  The intention is for the Kubelet Scraper component to be deployed onto Windows nodes.

Using `docker build` and not `buildx` because of Windows https://docs.docker.com/reference/cli/docker/build-legacy/

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  