### PR TITLE
chore: update target repo for windows-based infra agent

### DIFF
--- a/.github/workflows/windows-infra-agent.yml
+++ b/.github/workflows/windows-infra-agent.yml
@@ -27,7 +27,7 @@ jobs:
             tag: ltsc2022
     runs-on: ${{ matrix.windows.runner }}
     env:
-      AGENT_VERSION: 1.62.0 # hard-coded agent version for now
+      AGENT_VERSION: 1.63.0 # hard-coded agent version for now
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -68,7 +68,7 @@ jobs:
             --build-arg AGENT_VERSION="${{ env.AGENT_VERSION }}" `
             --platform windows/amd64 `
             -f Dockerfile.infraAgent `
-            -t newrelic/nri-kubernetes:agent-${{ env.AGENT_VERSION }}-windows-${{ matrix.windows.tag }}-alpha-$Env:tag .
+            -t newrelic/infrastructure-windows:agent-${{ env.AGENT_VERSION }}-windows-${{ matrix.windows.tag }}-alpha-$Env:tag .
 
       - uses: actions/cache@v4
         with:
@@ -102,4 +102,4 @@ jobs:
         shell: powershell
         run: |
           docker push newrelic/nri-kubernetes:windows-${{ matrix.windows.tag }}-alpha-$Env:tag
-          docker push newrelic/nri-kubernetes:agent-${{ env.AGENT_VERSION }}-windows-${{ matrix.windows.tag }}-alpha-$Env:tag
+          docker push newrelic/infrastructure-windows:agent-${{ env.AGENT_VERSION }}-windows-${{ matrix.windows.tag }}-alpha-$Env:tag


### PR DESCRIPTION
## Description
This updates the GHA that builds the Windows nri-kubernetes & agent images to use the new agent repo.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  