### PR TITLE
chore: login to dockerhub before running minikube

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,10 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.K8S_AGENTS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         with:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -66,6 +66,10 @@ jobs:
               echo "No unit tests found for $chart"
             fi
           done
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.K8S_AGENTS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.1
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
## Description
When running `actions-setup-minikube`, we sometimes get throttled by docker because the module is making unauthenticated requests. I'm not 100% sure logging into docker outside the modules saves us from this, but it's worth a shot.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  