### PR TITLE
chore: make windows agent runnable by ContainerUser

### DIFF
--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
@@ -105,7 +105,7 @@ spec:
           imagePullPolicy: {{ $.Values.images.agent.pullPolicy }}
           securityContext:
             windowsOptions:
-              runAsUserName: "ContainerAdministrator"
+              runAsUserName: "ContainerUser"
           ports:
             - containerPort: {{ get (fromYaml (include "nriKubernetes.kubelet.agentConfig" $)) "http_server_port" }}
           env:
@@ -180,8 +180,6 @@ spec:
               mountPath: "C:\\ProgramData\\New Relic\\newrelic-infra\\data"
             - name: agent-tmpfs-user-data
               mountPath: "C:\\ProgramData\\New Relic\\newrelic-infra\\user_data"
-            - name: agent-tmpfs-tmp
-              mountPath: "C:\\ProgramData\\New Relic\\newrelic-infra\\tmp"
             {{- with $.Values.kubelet.extraVolumeMounts }}
             {{- toYaml $ | nindent 12 }}
             {{- end }}
@@ -192,8 +190,6 @@ spec:
         - name: agent-tmpfs-data
           emptyDir: {}
         - name: agent-tmpfs-user-data
-          emptyDir: {}
-        - name: agent-tmpfs-tmp
           emptyDir: {}
         - name: nri-kubernetes-config
           configMap:

--- a/charts/newrelic-infrastructure/tests/securityContext_test.yaml
+++ b/charts/newrelic-infrastructure/tests/securityContext_test.yaml
@@ -214,7 +214,7 @@ tests:
           path: spec.template.spec.containers[1].securityContext
           value:
             windowsOptions:
-              runAsUserName: 'ContainerAdministrator'
+              runAsUserName: 'ContainerUser'
         documentIndex: 0
         template: templates/kubelet/daemonset-windows.yaml
       - equal:
@@ -228,12 +228,12 @@ tests:
           path: spec.template.spec.containers[1].securityContext
           value:
             windowsOptions:
-              runAsUserName: 'ContainerAdministrator'
+              runAsUserName: 'ContainerUser'
         documentIndex: 1
         template: templates/kubelet/daemonset-windows.yaml
 
-  - it: securityContext of linux containers not overwritten by windows defaults 
-    set: 
+  - it: securityContext of linux containers not overwritten by windows defaults
+    set:
       licenseKey: test
       cluster: test
       enableWindows: true
@@ -252,7 +252,7 @@ tests:
           path: spec.template.spec.containers[1].securityContext
           value:
             windowsOptions:
-              runAsUserName: 'ContainerAdministrator'
+              runAsUserName: 'ContainerUser'
         documentIndex: 0
         template: templates/kubelet/daemonset-windows.yaml
       - equal:

--- a/windows/infrastructure-agent/Dockerfile.infraAgent
+++ b/windows/infrastructure-agent/Dockerfile.infraAgent
@@ -16,13 +16,16 @@ RUN Remove-Item \"C:\\newrelic-infra.$Env:AGENT_VERSION.msi\"
 # Service is not started by default
 RUN Set-Service -Name 'newrelic-infra' -StartupType disabled
 
+# Grant permissions to the ContainerUser for directory access
+RUN icacls 'C:\ProgramData\New Relic\newrelic-infra' /grant Users:'(OI)(CI)M' /T
+
 # we use this to start the agent, and to get the output from its log file
 COPY start.ps1 C:\\start.ps1
 ENTRYPOINT ["powershell", "C:\\start.ps1"]
 
-ENV NRIA_IS_CONTAINERIZED true
-ENV NRIA_OVERRIDE_HOST_ROOT ""
-ENV NRIA_IS_SECURE_FORWARD_ONLY true
-ENV NRIA_HTTP_SERVER_ENABLED true
-ENV NRIA_HTTP_SERVER_PORT 8003
-ENV NRIA_LOG_FORWARD true
+ENV NRIA_IS_CONTAINERIZED=true
+ENV NRIA_OVERRIDE_HOST_ROOT=""
+ENV NRIA_IS_SECURE_FORWARD_ONLY=true
+ENV NRIA_HTTP_SERVER_ENABLED=true
+ENV NRIA_HTTP_SERVER_PORT=8003
+ENV NRIA_LOG_FORWARD=true


### PR DESCRIPTION
## Description
To improve our security posture for the new Windows integration, the infrastructure agent container that runs in the windows kubelet pod should be runnable by a user with reduced permissions. We can use the virtual user `ContainerUser` rather than `ContainerAdministrator` by granting modify permissions to `Users` for the relevant path in the infra agent Docker file & removing the `emptyDir` mount path for the `\tmp` directory. Agent code deletes this directory during startup, which can apparently be done by the `ContainerAdministrator` but not the `ContainerUser` no matter how many permissions you give it. The agent will manage creating the directory itself.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  