### PR TITLE
add permissions to gha to remove medium security alerts

### DIFF
--- a/.github/workflows/build-win-infra-agent.yml
+++ b/.github/workflows/build-win-infra-agent.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'charts/newrelic-infrastructure/values.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   check-version-change:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-windows-integration-test.yml
+++ b/.github/workflows/build-windows-integration-test.yml
@@ -9,6 +9,10 @@ on:
       - windowsImage*
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     name: Build integration for

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-changelog:
     uses: newrelic/k8s-agents-automation/.github/workflows/reusable-changelog.yml@main

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - renovate/**
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   e2eTests:
     # Do not run e2e tests if commit message or PR has skip-e2e.

--- a/.github/workflows/nightlyAndMainImage.yml
+++ b/.github/workflows/nightlyAndMainImage.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
 

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -8,6 +8,10 @@ on:
       - main
       - renovate/**
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     name: Build integration for

--- a/.github/workflows/release-e2e-resources.yaml
+++ b/.github/workflows/release-e2e-resources.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 # Prevent two release workflows from running concurrently, which might cause WAR race conditions in the repository
 # Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency: helm-e2e-resources

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -12,6 +12,8 @@ jobs:
   repolint:
     name: Run Repolinter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # checkout the repository and read workflow files
     steps:
       - name: Test Default Branch
         id: default-branch

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Repolinter
     runs-on: ubuntu-latest
     permissions:
-      contents: read   # checkout the repository and read workflow files
+      contents: read
     steps:
       - name: Test Default Branch
         id: default-branch

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -5,7 +5,7 @@ name: Trigger release creation
 # For more details about how to release follow https://github.com/newrelic/coreint-automation/blob/main/docs/release_runbook.md
 
 permissions:
-  actions: write # To trigger the reusable workflow
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -4,6 +4,9 @@ name: Trigger release creation
 # This workflow should be triggered merely from the default branch.
 # For more details about how to release follow https://github.com/newrelic/coreint-automation/blob/main/docs/release_runbook.md
 
+permissions:
+  actions: write # To trigger the reusable workflow
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
## Description
- to clean up all the new Medium security code scan alerts we were getting and reduce noise 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  