### PR TITLE
add timeframe for windows e2e queries

### DIFF
--- a/e2e/test-specs-windows.yml
+++ b/e2e/test-specs-windows.yml
@@ -21,991 +21,991 @@ scenarios:
     tests:
       nrqls:
 #       START Windows Cronjob 2019
-        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.isComplete is not null) AS 'Completed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.isComplete is not null) AS 'Completed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Completed Jobs"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.failed is not null) AS 'Failed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.failed is not null) AS 'Failed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Failed Jobs"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.cronjob.isActive) as 'Active Jobs' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2019-cronjob' # TODO make specific to windows
+        - query: FROM Metric SELECT latest(k8s.cronjob.isActive) as 'Active Jobs' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
             - key: "Active Jobs"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2019-cronjob' # TODO make specific to windows
+        - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
             - key: "constant"
               value: False
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
             - key: "schedule"
               value: "* * * * *"
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
             - key: "concurrencyPolicy"
               value: "Allow"
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
             - key: "created"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
             - key: "lastScheduled"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.startedAt) AS started WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.startedAt) AS started WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "started"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.completedAt) AS completed WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.completedAt) AS completed WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "completed"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.specParallelism) AS 'Parallelism' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.specParallelism) AS 'Parallelism' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Parallelism"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT latest(k8s.job.specCompletions) AS 'Completions' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.specCompletions) AS 'Completions' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Completions"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT latest(k8s.job.specActiveDeadlineSeconds) AS 'Active Deadline (sec)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.specActiveDeadlineSeconds) AS 'Active Deadline (sec)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Active Deadline (sec)"
               lowerBoundedValue: 540.0
-        - query: FROM Metric SELECT latest(k8s.job.createdAt) AS created WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.createdAt) AS created WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2019-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "created"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' FACET k8s.nodeName as 'nodename'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' FACET k8s.nodeName as 'nodename'  since 20 minutes ago
           expected_results:
             - key: "ready"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' FACET k8s.nodeName as 'nodename'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' FACET k8s.nodeName as 'nodename' since 20 minutes ago
           expected_results:
             - key: "scheduled"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.container.memoryRequestedBytes) / 1024 / 1024 as 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.memoryRequestedBytes) / 1024 / 1024 as 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100
-        - query: FROM Metric SELECT latest(k8s.container.memoryLimitBytes) / 1024 / 1024 as 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.memoryLimitBytes) / 1024 / 1024 as 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200
-        - query: FROM Metric SELECT latest(k8s.container.cpuRequestedCores) as 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.cpuRequestedCores) as 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.25
-        - query: FROM Metric SELECT latest(k8s.container.cpuLimitCores) as 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.cpuLimitCores) as 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.5
-        - query: FROM Metric SELECT latest(k8s.container.restartCountDelta) as 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.restartCountDelta) as 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.container.restartCount) as 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.restartCount) as 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2019-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #        END Windows Cronjob 2019
 #        START Windows Cronjob 2022
-        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.isComplete is not null) AS 'Completed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.isComplete is not null) AS 'Completed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Completed Jobs"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.failed is not null) AS 'Failed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT filter(uniqueCount(k8s.jobName), where k8s.job.failed is not null) AS 'Failed Jobs' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Failed Jobs"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.cronjob.isActive) as 'Active Jobs' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2022-cronjob' # TODO make specific to windows
+        - query: FROM Metric SELECT latest(k8s.cronjob.isActive) as 'Active Jobs' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
             - key: "Active Jobs"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2022-cronjob' # TODO make specific to windows
+        - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
             - key: "constant"
               value: False
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
             - key: "schedule"
               value: "* * * * *"
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
             - key: "concurrencyPolicy"
               value: "Allow"
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
             - key: "created"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob'
+        - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
             - key: "lastScheduled"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.startedAt) AS started WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.startedAt) AS started WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "started"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.completedAt) AS completed WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.completedAt) AS completed WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "completed"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.specParallelism) AS 'Parallelism' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.specParallelism) AS 'Parallelism' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Parallelism"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT latest(k8s.job.specCompletions) AS 'Completions' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.specCompletions) AS 'Completions' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Completions"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT latest(k8s.job.specActiveDeadlineSeconds) AS 'Active Deadline (sec)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.specActiveDeadlineSeconds) AS 'Active Deadline (sec)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "Active Deadline (sec)"
               lowerBoundedValue: 540.0
-        - query: FROM Metric SELECT latest(k8s.job.createdAt) AS created WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%'
+        - query: FROM Metric SELECT latest(k8s.job.createdAt) AS created WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName LIKE '${SCENARIO_TAG}-resources-win-2022-cronjob-%' since 20 minutes ago
           expected_results:
             - key: "created"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' FACET k8s.nodeName as 'nodename'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' FACET k8s.nodeName as 'nodename' since 20 minutes ago
           expected_results:
             - key: "ready"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' FACET k8s.nodeName as 'nodename'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) as 'ready', latest(k8s.pod.isScheduled) as 'scheduled', latest(k8s.status) as 'status' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' FACET k8s.nodeName as 'nodename' since 20 minutes ago
           expected_results:
             - key: "scheduled"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.container.memoryRequestedBytes) / 1024 / 1024 as 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.memoryRequestedBytes) / 1024 / 1024 as 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100
-        - query: FROM Metric SELECT latest(k8s.container.memoryLimitBytes) / 1024 / 1024 as 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.memoryLimitBytes) / 1024 / 1024 as 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200
-        - query: FROM Metric SELECT latest(k8s.container.cpuRequestedCores) as 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.cpuRequestedCores) as 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.25
-        - query: FROM Metric SELECT latest(k8s.container.cpuLimitCores) as 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.cpuLimitCores) as 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.5
-        - query: FROM Metric SELECT latest(k8s.container.restartCountDelta) as 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.restartCountDelta) as 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.container.restartCount) as 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT latest(k8s.container.restartCount) as 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName like '${SCENARIO_TAG}-resources-win-2022-cronjob-%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #         END Windows Cronjob 2022
 #         START Windows StatefulSet 2019
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Total"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsCurrent) AS 'Pods Current' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsCurrent) AS 'Pods Current' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Current"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Updated"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.createdAt) AS 'Created At' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.createdAt) AS 'Created At' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Created At"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Total"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.currentRevision) AS 'Current Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.currentRevision) AS 'Current Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Current Revision"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.updateRevision) AS 'Update Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.updateRevision) AS 'Update Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Update Revision"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pod Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-statefulset'
+        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pod Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100.0
-        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200.0
-        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.250
-        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.500
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #         END Windows 2019 StatefulSet
 #         START Windows 2022 StatefulSet
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Total"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsCurrent) AS 'Pods Current' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsCurrent) AS 'Pods Current' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Current"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Updated"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.createdAt) AS 'Created At' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.createdAt) AS 'Created At' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Created At"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pods Total"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.currentRevision) AS 'Current Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.currentRevision) AS 'Current Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Current Revision"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.statefulset.updateRevision) AS 'Update Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.statefulset.updateRevision) AS 'Update Revision' WHERE metricName = 'k8s.statefulset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.statefulsetName = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Update Revision"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pod Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-statefulset'
+        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'StatefulSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-statefulset' since 20 minutes ago
           expected_results:
             - key: "Pod Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100.0
-        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200.0
-        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.250
-        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.500
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-statefulset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #         END Windows 2022 StatefulSet
 #         START Windows 2019 Deployment
-        - query: FROM Metric SELECT latest(k8s.deployment.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Available"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Total"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Updated"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Unavailable"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsMaxUnavailable) AS 'Pods MaxUnavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsMaxUnavailable) AS 'Pods MaxUnavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods MaxUnavailable"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Pods Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.createdAt) AS 'Created At' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.createdAt) AS 'Created At' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Created At"
               lowerBoundedValue: 0.0
               #
-        - query: FROM Metric SELECT latest(k8s.deployment.conditionAvailable) AS 'Condition Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.conditionAvailable) AS 'Condition Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Condition Available"
               value: "true"
-        - query: FROM Metric SELECT latest(k8s.deployment.conditionProgressing) AS 'Condition Progressing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.conditionProgressing) AS 'Condition Progressing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Condition Progressing"
               value: "true"
-        - query: FROM Metric SELECT latest(k8s.deployment.isPaused) AS 'Paused' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.isPaused) AS 'Paused' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Paused"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.metadataGeneration) AS 'Metadata Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.metadataGeneration) AS 'Metadata Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Metadata Generation"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.observedGeneration) AS 'Observed Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019'
+        - query: FROM Metric SELECT latest(k8s.deployment.observedGeneration) AS 'Observed Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' since 20 minutes ago
           expected_results:
             - key: "Observed Generation"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' since 20 minutes ago
           expected_results:
             - key: "Pod Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%'
+        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' since 20 minutes ago
           expected_results:
             - key: "Pod Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100.0
-        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200.0
-        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.250
-        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.500
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2019' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2019' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #         END Windows 2019 Deployment
 #         START Windows 2022 Deployment
-        - query: FROM Metric SELECT latest(k8s.deployment.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Available"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsTotal) AS 'Pods Total' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Total"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsUpdated) AS 'Pods Updated' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Updated"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Unavailable"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsMaxUnavailable) AS 'Pods MaxUnavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsMaxUnavailable) AS 'Pods MaxUnavailable' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods MaxUnavailable"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Pods Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.createdAt) AS 'Created At' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.createdAt) AS 'Created At' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Created At"
               lowerBoundedValue: 0.0
               #
-        - query: FROM Metric SELECT latest(k8s.deployment.conditionAvailable) AS 'Condition Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.conditionAvailable) AS 'Condition Available' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Condition Available"
               value: "true"
-        - query: FROM Metric SELECT latest(k8s.deployment.conditionProgressing) AS 'Condition Progressing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.conditionProgressing) AS 'Condition Progressing' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Condition Progressing"
               value: "true"
-        - query: FROM Metric SELECT latest(k8s.deployment.isPaused) AS 'Paused' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.isPaused) AS 'Paused' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Paused"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.deployment.metadataGeneration) AS 'Metadata Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.metadataGeneration) AS 'Metadata Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Metadata Generation"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.deployment.observedGeneration) AS 'Observed Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022'
+        - query: FROM Metric SELECT latest(k8s.deployment.observedGeneration) AS 'Observed Generation' WHERE metricName = 'k8s.deployment.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' since 20 minutes ago
           expected_results:
             - key: "Observed Generation"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' since 20 minutes ago
           expected_results:
             - key: "Pod Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%'
+        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' since 20 minutes ago
           expected_results:
             - key: "Pod Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100.0
-        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200.0
-        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.250
-        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.500
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.deploymentName = '${SCENARIO_TAG}-resources-win-2022' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win%' AND k8s.containerName = 'windows-server-2022' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #        END Windows 2022 Deployment
 #        START Windows 2019 DaemonSet
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Available"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods UpdatedScheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Unavailable"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Misscheduled"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.createdAt) AS 'Created At' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.createdAt) AS 'Created At' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Created At"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Available"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Unavailable"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods UpdatedScheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Misscheduled"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pod Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pod Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT max(k8s.pod.netTxBytesPerSecond) / 1000 AS 'Transferred (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT max(k8s.pod.netTxBytesPerSecond) / 1000 AS 'Transferred (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Transferred (KBps)"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT max(k8s.pod.netRxBytesPerSecond) / 1000 AS 'Received (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset'
+        - query: FROM Metric SELECT max(k8s.pod.netRxBytesPerSecond) / 1000 AS 'Received (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2019-daemonset' since 20 minutes ago
           expected_results:
             - key: "Received (KBps)"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100.0
-        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200.0
-        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.25
-        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.5
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2019-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #        END Windows 2019 DaemonSet
 #        START Windows 2022 DaemonSet
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Available"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsReady) AS 'Pods Ready' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods UpdatedScheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Unavailable"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Misscheduled"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.createdAt) AS 'Created At' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.createdAt) AS 'Created At' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Created At"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsDesired) AS 'Pods Desired' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Desired"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMissing) AS 'Pods Missing' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Missing"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsAvailable) AS 'Pods Available' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Available"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUnavailable) AS 'Pods Unavailable' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Unavailable"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsScheduled) AS 'Pods Scheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsUpdatedScheduled) AS 'Pods UpdatedScheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods UpdatedScheduled"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.daemonset.podsMisscheduled) AS 'Pods Misscheduled' WHERE metricName = 'k8s.daemonset.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.daemonsetName = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pods Misscheduled"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.pod.isReady) AS 'Pod Ready' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pod Ready"
               value: 1.0
-        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT latest(k8s.pod.isScheduled) AS 'Pod Scheduled' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Pod Scheduled"
               value: 1.0
-        - query: FROM Metric SELECT max(k8s.pod.netTxBytesPerSecond) / 1000 AS 'Transferred (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT max(k8s.pod.netTxBytesPerSecond) / 1000 AS 'Transferred (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Transferred (KBps)"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT max(k8s.pod.netRxBytesPerSecond) / 1000 AS 'Received (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset'
+        - query: FROM Metric SELECT max(k8s.pod.netRxBytesPerSecond) / 1000 AS 'Received (KBps)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.createdKind = 'DaemonSet' AND k8s.createdBy = '${SCENARIO_TAG}-resources-win-2022-daemonset' since 20 minutes ago
           expected_results:
             - key: "Received (KBps)"
               lowerBoundedValue: 0.0
-        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryRequestedBytes) / 1024 / 1024 AS 'Memory Requested (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Requested (MiB)"
               value: 100.0
-        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryLimitBytes) / 1024 / 1024 AS 'Memory Limit (MiB)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory Limit (MiB)"
               value: 200.0
-        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuRequestedCores) AS 'CPU Requested (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Requested (cores)"
               value: 0.25
-        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuLimitCores) AS 'CPU Limit (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU Limit (cores)"
               value: 0.5
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Restarts delta' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts delta"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCount) AS 'Restarts cumulative' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Restarts cumulative"
               value: 0.0
-        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuUsedCores) AS 'CPU usage (cores)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU usage (cores)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.cpuCoresUtilization) / 100 AS 'CPU utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "CPU utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetBytes) AS 'Memory usage (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory usage (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.memoryWorkingSetUtilization) / 100 AS 'Memory utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Memory utilization (%)"
               lowerBoundedValue: 0.01
-        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedBytes) AS 'Filesystem used (bytes)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem used (bytes)"
               lowerBoundedValue: 1.0
-        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.fsUsedPercent) / 100 AS 'Filesystem Utilization (%)' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Filesystem Utilization (%)"
               lowerBoundedValue: 0.0000001
-        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text'
+        - query: FROM Metric SELECT max(k8s.container.restartCountDelta) AS 'Container restarts' WHERE k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.podName LIKE '${SCENARIO_TAG}-resources-win-2022-daemonset%' AND k8s.containerName = 'random-text' since 20 minutes ago
           expected_results:
             - key: "Container restarts"
               value: 0.0
 #        END Windows 2022 DaemonSet
 #        START Windows 2019 Failed Job
-        - query: FROM Metric SELECT latest(k8s.job.activePods) AS 'Active Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT latest(k8s.job.activePods) AS 'Active Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "Active Pods"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.succeededPods) AS 'Succeeded Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT latest(k8s.job.succeededPods) AS 'Succeeded Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "Succeeded Pods"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.failedPods) AS 'Failed Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT latest(k8s.job.failedPods) AS 'Failed Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "Failed Pods"
               value: 1.0
-        - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "constant"
               value: "Failed"
-        - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "constant"
               value: "-"
 #        END Windows 2019 Failed Job
 #        START Windows 2022 Failed Job
-        - query: FROM Metric SELECT latest(k8s.job.activePods) AS 'Active Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT latest(k8s.job.activePods) AS 'Active Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "Active Pods"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.succeededPods) AS 'Succeeded Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT latest(k8s.job.succeededPods) AS 'Succeeded Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "Succeeded Pods"
               value: 0.0
-        - query: FROM Metric SELECT latest(k8s.job.failedPods) AS 'Failed Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT latest(k8s.job.failedPods) AS 'Failed Pods' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "Failed Pods"
               value: 1.0
-        - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "constant"
               value: "Failed"
-        - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob'
+        - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
             - key: "constant"
               value: "-"


### PR DESCRIPTION
## Description
- e2e tests were failing because an old node's data was still in NR Platform and the facet query count was wrong. 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [X] E2E tests
  