### PR TITLE
chore: Update e2e windows scenario tag

### DIFF
--- a/.github/workflows/test-windows-e2e.yml
+++ b/.github/workflows/test-windows-e2e.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - testWindows-*
+      - test-windows-*
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-windows-e2e.yml
+++ b/.github/workflows/test-windows-e2e.yml
@@ -116,7 +116,7 @@ jobs:
           retry_seconds: 60
           retry_attempts: 5
           agent_enabled: false
-          scenario_tag: ${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.kubernetes_version}}
+          scenario_tag: ${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.eks_cluster_name }}
           spec_path: e2e/test-specs-windows.yml
           account_id: ${{ secrets.K8S_AGENTS_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.K8S_AGENTS_E2E_API_KEY }}

--- a/.github/workflows/test-windows-e2e.yml
+++ b/.github/workflows/test-windows-e2e.yml
@@ -60,6 +60,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - name: Create Cluster Specific Scenario Tag and Namespace Env
+        run: |
+          echo "scenario_tag=${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.eks_cluster_name }}" >> $GITHUB_ENV
+          new_namespace="nr-${{ env.scenario_tag }}"
+          echo "new_namespace=$new_namespace" >> $GITHUB_ENV
       - name: Configure AWS Credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -82,11 +87,10 @@ jobs:
           password: ${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
       - name: Setup Access to Private Docker Registry
         run: |
-          namespace="nr-${{ needs.generate-key.outputs.run_key }}"
-          kubectl create namespace $namespace || echo "Namespace $namespace already exists, skipping creation."
+          kubectl create namespace ${{ env.new_namespace }} || echo "Namespace ${{ env.new_namespace }} already exists, skipping creation."
 
-          if ! kubectl get secret "nri-kubernetes-internal-dockerhub" >/dev/null 2>&1; then
-            kubectl create secret docker-registry nri-kubernetes-internal-dockerhub -n nr-${{ needs.generate-key.outputs.run_key }}\
+          if ! kubectl get secret "nri-kubernetes-internal-dockerhub" -n ${{ env.new_namespace }} >/dev/null 2>&1; then
+            kubectl create secret docker-registry nri-kubernetes-internal-dockerhub -n ${{ env.new_namespace }} \
               --docker-server=docker.io \
               --docker-username=${{ secrets.K8S_AGENTS_DOCKERHUB_USERNAME }} \
               --docker-password=${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
@@ -116,7 +120,7 @@ jobs:
           retry_seconds: 60
           retry_attempts: 5
           agent_enabled: false
-          scenario_tag: ${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.eks_cluster_name }}
+          scenario_tag: ${{ env.scenario_tag }}
           spec_path: e2e/test-specs-windows.yml
           account_id: ${{ secrets.K8S_AGENTS_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.K8S_AGENTS_E2E_API_KEY }}
@@ -124,6 +128,6 @@ jobs:
       - name: Cleanup Testing Resources
         if: always()
         run: |
-          helm uninstall ${{needs.generate-key.outputs.run_key}} -n nr-${{ needs.generate-key.outputs.run_key }} || echo "Helm release ${{ needs.generate-key.outputs.run_key }} already deleted or does not exist."
-          helm uninstall ${{needs.generate-key.outputs.run_key}}-resources -n nr-${{ needs.generate-key.outputs.run_key }} || echo "Helm release ${{ needs.generate-key.outputs.run_key }}-resources already deleted or does not exist."
-          kubectl delete namespace nr-${{ needs.generate-key.outputs.run_key }} || echo "Namespace nr-${{ needs.generate-key.outputs.run_key }} already deleted or does not exist."
+          helm uninstall ${{ env.scenario_tag }} -n ${{ env.new_namespace }} || echo "Helm release ${{ env.scenario_tag }} already deleted or does not exist."
+          helm uninstall ${{ env.scenario_tag }}-resources -n ${{ env.new_namespace }} || echo "Helm release ${{ env.scenario_tag }}-resources already deleted or does not exist."
+          kubectl delete namespace ${{ env.new_namespace }} || echo "Namespace ${{ env.new_namespace }} already deleted or does not exist."

--- a/.github/workflows/test-windows-e2e.yml
+++ b/.github/workflows/test-windows-e2e.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - testWindows/*
+      - testWindows-*
   pull_request:
     branches:
       - main
@@ -116,7 +116,7 @@ jobs:
           retry_seconds: 60
           retry_attempts: 5
           agent_enabled: false
-          scenario_tag: ${{ needs.generate-key.outputs.run_key }}
+          scenario_tag: ${{ needs.generate-key.outputs.run_key }}+${{ matrix.runner.kubernetes_version}}
           spec_path: e2e/test-specs-windows.yml
           account_id: ${{ secrets.K8S_AGENTS_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.K8S_AGENTS_E2E_API_KEY }}

--- a/.github/workflows/test-windows-e2e.yml
+++ b/.github/workflows/test-windows-e2e.yml
@@ -61,10 +61,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Create Cluster Specific Scenario Tag and Namespace Env
+        id: create-scenario-tag-and-ns
         run: |
-          echo "scenario_tag=${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.eks_cluster_name }}" >> $GITHUB_ENV
-          new_namespace="nr-${{ env.scenario_tag }}"
-          echo "new_namespace=$new_namespace" >> $GITHUB_ENV
+          scenario_tag="${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.eks_cluster_name }}"
+          echo "scenario_tag=$scenario_tag" >> "$GITHUB_OUTPUT"
+          new_namespace="nr-$scenario_tag"
+          echo "new_namespace=$new_namespace" >> "$GITHUB_OUTPUT"
       - name: Configure AWS Credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -86,11 +88,13 @@ jobs:
           username: ${{ secrets.K8S_AGENTS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
       - name: Setup Access to Private Docker Registry
+        env:
+          NEW_NAMESPACE: ${{ steps.create-scenario-tag-and-ns.outputs.new_namespace }}
         run: |
-          kubectl create namespace ${{ env.new_namespace }} || echo "Namespace ${{ env.new_namespace }} already exists, skipping creation."
+          kubectl create namespace $NEW_NAMESPACE || echo "Namespace $NEW_NAMESPACE already exists, skipping creation."
 
-          if ! kubectl get secret "nri-kubernetes-internal-dockerhub" -n ${{ env.new_namespace }} >/dev/null 2>&1; then
-            kubectl create secret docker-registry nri-kubernetes-internal-dockerhub -n ${{ env.new_namespace }} \
+          if ! kubectl get secret "nri-kubernetes-internal-dockerhub" -n $NEW_NAMESPACE >/dev/null 2>&1; then
+            kubectl create secret docker-registry nri-kubernetes-internal-dockerhub -n $NEW_NAMESPACE \
               --docker-server=docker.io \
               --docker-username=${{ secrets.K8S_AGENTS_DOCKERHUB_USERNAME }} \
               --docker-password=${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
@@ -120,14 +124,17 @@ jobs:
           retry_seconds: 60
           retry_attempts: 5
           agent_enabled: false
-          scenario_tag: ${{ env.scenario_tag }}
+          scenario_tag: ${{ steps.create-scenario-tag-and-ns.outputs.scenario_tag }}
           spec_path: e2e/test-specs-windows.yml
           account_id: ${{ secrets.K8S_AGENTS_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.K8S_AGENTS_E2E_API_KEY }}
           license_key: ${{ secrets.K8S_AGENTS_E2E_LICENSE_KEY }}
       - name: Cleanup Testing Resources
         if: always()
+        env:
+          NEW_NAMESPACE: ${{ steps.create-scenario-tag-and-ns.outputs.new_namespace }}
+          SCENARIO_TAG: ${{ steps.create-scenario-tag-and-ns.outputs.scenario_tag }}
         run: |
-          helm uninstall ${{ env.scenario_tag }} -n ${{ env.new_namespace }} || echo "Helm release ${{ env.scenario_tag }} already deleted or does not exist."
-          helm uninstall ${{ env.scenario_tag }}-resources -n ${{ env.new_namespace }} || echo "Helm release ${{ env.scenario_tag }}-resources already deleted or does not exist."
-          kubectl delete namespace ${{ env.new_namespace }} || echo "Namespace ${{ env.new_namespace }} already deleted or does not exist."
+          helm uninstall $SCENARIO_TAG -n $NEW_NAMESPACE || echo "Helm release $SCENARIO_TAG already deleted or does not exist."
+          helm uninstall $SCENARIO_TAG-resources -n $NEW_NAMESPACE || echo "Helm release $SCENARIO_TAG-resources already deleted or does not exist."
+          kubectl delete namespace $NEW_NAMESPACE || echo "Namespace $NEW_NAMESPACE already deleted or does not exist."

--- a/.github/workflows/test-windows-e2e.yml
+++ b/.github/workflows/test-windows-e2e.yml
@@ -116,7 +116,7 @@ jobs:
           retry_seconds: 60
           retry_attempts: 5
           agent_enabled: false
-          scenario_tag: ${{ needs.generate-key.outputs.run_key }}+${{ matrix.runner.kubernetes_version}}
+          scenario_tag: ${{ needs.generate-key.outputs.run_key }}-${{ matrix.runner.kubernetes_version}}
           spec_path: e2e/test-specs-windows.yml
           account_id: ${{ secrets.K8S_AGENTS_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.K8S_AGENTS_E2E_API_KEY }}

--- a/e2e/e2e-values-windows-template.yml
+++ b/e2e/e2e-values-windows-template.yml
@@ -11,12 +11,12 @@ enableWindows: true
 windowsOsList:
 #  # Limited support for only LTSC2019/LTSC2022: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#windows-os-version-support
   - version: ltsc2019
-    imageTagSuffix: windows-ltsc-2019
+    imageTagSuffix: ltsc2019
     buildNumber: 10.0.17763
-    agentImage: "newrelic/infrastructure-windows:1.64.0-ltsc2019"
+    agentImage: "newrelic/infrastructure-windows:1.65.3-ltsc2019"
     integrationImage: $IMAGE_2019
   - version: ltsc2022
-    imageTagSuffix: windows-ltsc-2022
+    imageTagSuffix: ltsc2022
     buildNumber: 10.0.20348
-    agentImage: "newrelic/infrastructure-windows:1.64.0-ltsc2022"
+    agentImage: "newrelic/infrastructure-windows:1.65.3-ltsc2022"
     integrationImage: $IMAGE_2022

--- a/e2e/test-specs-windows.yml
+++ b/e2e/test-specs-windows.yml
@@ -12,7 +12,7 @@ scenarios:
       - echo "Installing e2e-resources using SCENARIO_TAG ${SCENARIO_TAG}"; KSM_IMAGE_VERSION="v2.13.0"; echo "Will use KSM image version ${KSM_IMAGE_VERSION}" && helm upgrade --install ${SCENARIO_TAG}-resources --namespace nr-${SCENARIO_TAG} --create-namespace ../charts/internal/e2e-resources --set persistentVolume.enabled=true --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION} --set windows.is2019=true --set windows.is2022=true --set demo.enabled=true
       - helm upgrade --install ${SCENARIO_TAG} --namespace nr-${SCENARIO_TAG} --create-namespace ../charts/newrelic-infrastructure --values e2e-values-windows.yml --set global.licenseKey=${LICENSE_KEY} --set global.cluster=${SCENARIO_TAG} --set enableWindows=true
       # Allow for resources to settle before starting checks
-      - sleep 540 # Windows resources take longer to settle
+      - sleep 480 # Windows resources take longer to settle
     after:
       - kubectl logs --selector app.kubernetes.io/name=newrelic-infrastructure --namespace nr-${SCENARIO_TAG} --all-containers --prefix=true
       - kubectl get pods --namespace nr-${SCENARIO_TAG}


### PR DESCRIPTION
## Description
- making sure the scenario tag for tests on cluster v1.29 (or oldest) and v1.32 (newest) cluster versions are different so the E2E test queries don't get confused
- decrease sleep time for test-spec-windows
- 
## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [x] E2E tests
  