### PR TITLE
Updating docker image for CVEs && Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.22.1
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --upgrade && apk add --no-cache tini curl bind-tools
+RUN apk update && apk upgrade --no-cache && apk add --no-cache tini curl bind-tools
 
 COPY bin/nri-kubernetes-${TARGETOS}-${TARGETARCH} /bin/
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ and review the description of all
 
 ## Development
 
+### Build local docker image
+
+```bash
+make compile-multiarch
+docker build -t nri-kubernetes:local .
+```
+
 ### Run e2e Tests
 
 * See [e2e/README.md](./e2e/README.md) for more details regarding running e2e tests.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

Updating docker file to update local packages. 
I _think_ this command was intended to do this already
```Bash
apk add --no-cache --upgrade
```

However `apk add` has no effect without giving it some packages to act upon. 
So with this command, we are still getting OS level CVEs that already have patches. 
<img width="1222" height="501" alt="Screenshot 2025-10-06 at 3 25 11 PM" src="https://github.com/user-attachments/assets/cd70a636-b286-48ca-bfdd-75ba6581f778" />


after updating the update/upgrade command, we are no longer seeing those CVEs. 
<img width="913" height="317" alt="Screenshot 2025-10-06 at 3 26 05 PM" src="https://github.com/user-attachments/assets/f38dd51a-8fc4-4820-8317-bb01028230d5" />

Also added a quick comment about building locally in the README to help the next dev. 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [x] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  