### PR TITLE
fix: templating for priorityClassName when enableWindows=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### bugfix
+- Fix priorityClassName templating when enableWindows=true @kondracek-nr [#1329](https://github.com/newrelic/nri-kubernetes/pull/1329)
+
 ## v3.49.0 - 2025-11-03
 
 ### 🚀 Enhancements

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
@@ -48,7 +48,7 @@ spec:
         {{- . | nindent 8 }}
       {{- end }}
       {{- with include "newrelic.common.priorityClassName" $ }}
-      priorityClassName: {{ $ }}
+      priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" $ }}
       hostNetwork: false


### PR DESCRIPTION
## Description
A customer reported that when `enableWindows=true`, setting `priorityClassName` broke the YAML templating. This change fixes that.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  