### PR TITLE
Update e2e tests to remove usage of "constant"

### DIFF
--- a/e2e/test-specs-openshift.yml
+++ b/e2e/test-specs-openshift.yml
@@ -111,7 +111,7 @@ scenarios:
               lowerBoundedValue: 0.0
         - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt'
           expected_results:
-            - key: "constant"
+            - key: "Suspended"
               value: False
         # - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.clusterName = '${SCENARIO_TAG}'
         #   expected_results:
@@ -683,11 +683,11 @@ scenarios:
               value: 1.0
         - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-failjob'
           expected_results:
-            - key: "constant"
+            - key: "State"
               value: "Failed"
         - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-failjob'
           expected_results:
-            - key: "constant"
+            - key: "Duration (sec)"
               value: "-"
 #        END Failed Job
       entities: []
@@ -829,7 +829,7 @@ scenarios:
               lowerBoundedValue: 0.0
         - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt'
           expected_results:
-            - key: "constant"
+            - key: "Suspended"
               value: False
         # - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.clusterName = '${SCENARIO_TAG}'
         #   expected_results:
@@ -1401,11 +1401,11 @@ scenarios:
               value: 1.0
         - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-failjob'
           expected_results:
-            - key: "constant"
+            - key: "State"
               value: "Failed"
         - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-failjob'
           expected_results:
-            - key: "constant"
+            - key: "Duration (sec)"
               value: "-"
 #        END Failed Job
       entities: []

--- a/e2e/test-specs-windows.yml
+++ b/e2e/test-specs-windows.yml
@@ -35,7 +35,7 @@ scenarios:
               lowerBoundedValue: 0.0
         - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
-            - key: "constant"
+            - key: "Suspended"
               value: False
         - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2019-cronjob' since 20 minutes ago
           expected_results:
@@ -153,7 +153,7 @@ scenarios:
               lowerBoundedValue: 0.0
         - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt' AND entity.name like '%${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
-            - key: "constant"
+            - key: "Suspended"
               value: False
         - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.cronjobName = '${SCENARIO_TAG}-resources-win-2022-cronjob' since 20 minutes ago
           expected_results:
@@ -981,11 +981,11 @@ scenarios:
               value: 1.0
         - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
-            - key: "constant"
+            - key: "State"
               value: "Failed"
         - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
-            - key: "constant"
+            - key: "Duration (sec)"
               value: "-"
 #        END Windows 2019 Failed Job
 #        START Windows 2022 Failed Job
@@ -1003,11 +1003,11 @@ scenarios:
               value: 1.0
         - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
-            - key: "constant"
+            - key: "State"
               value: "Failed"
         - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-win-2019-failjob' since 20 minutes ago
           expected_results:
-            - key: "constant"
+            - key: "Duration (sec)"
               value: "-"
 #        END Windows 2022 Failed Job
       entities: []

--- a/e2e/test-specs.yml
+++ b/e2e/test-specs.yml
@@ -107,7 +107,7 @@ scenarios:
               lowerBoundedValue: 0.0
         - query: FROM Metric SELECT if(latest(k8s.cronjob.isSuspended) = 1, 'True', 'False') as 'Suspended' WHERE metricName = 'k8s.cronjob.createdAt'
           expected_results:
-            - key: "constant"
+            - key: "Suspended"
               value: False
         # - query: FROM Metric SELECT latest(k8s.cronjobName) AS cronjob, latest(k8s.namespaceName) AS namespace, latest(k8s.clusterName) AS cluster, latest(k8s.cronjob.schedule) AS schedule, latest(k8s.cronjob.concurrencyPolicy) as concurrencyPolicy, latest(k8s.cronjob.createdAt) * 1000 AS created, latest(k8s.cronjob.lastScheduledTime) * 1000 AS lastScheduled WHERE metricName = 'k8s.cronjob.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.clusterName = '${SCENARIO_TAG}'
         #   expected_results:
@@ -679,11 +679,11 @@ scenarios:
               value: 1.0
         - query: FROM Metric SELECT if(latest(k8s.job.isComplete), 'Complete', if(latest(k8s.job.failed), 'Failed', '-')) AS 'State' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-failjob'
           expected_results:
-            - key: "constant"
+            - key: "State"
               value: "Failed"
         - query: FROM Metric WITH k8s.job.completedAt - k8s.job.startedAt AS duration SELECT if(latest(duration), latest(duration), '-') AS 'Duration (sec)' WHERE metricName = 'k8s.job.createdAt' AND k8s.namespaceName = 'nr-${SCENARIO_TAG}' AND k8s.jobName = '${SCENARIO_TAG}-resources-failjob'
           expected_results:
-            - key: "constant"
+            - key: "Duration (sec)"
               value: "-"
 #        END Failed Job
       entities: []


### PR DESCRIPTION
## Description
In October, several of our e2e tests started failing because they did not recognize particular keys - we had to change them to `constant` in order for the test to pass. Now the tests aren't recognizing `constant` as a legitimate key. It's a mystery. 

For reference, here's the last PR that dealt with this: https://github.com/newrelic/nri-kubernetes/pull/1307/files

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  