### PR TITLE
chore: reduce tolerations for ksm deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancement
+- Reduce tolerations for KSM pods to improve behavior during node cordon/draining @kondracek-nr [#1350](https://github.com/newrelic/nri-kubernetes/pull/1350)
+
 ## v3.50.2 - 2025-11-24
 
 ### 🐞 Bug fixes

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -194,10 +194,22 @@ ksm:
   enabled: true
   annotations: {}
   # -- Tolerations for the KSM Deployment.
-  # @default -- Schedules in all tainted nodes
+  # @default -- Tolerates common node pressure taints but not unschedulable nodes
   tolerations:
-    - operator: "Exists"
+    # Tolerate common node pressure conditions
+    - key: "node.kubernetes.io/disk-pressure"
+      operator: "Exists"
       effect: "NoSchedule"
+    - key: "node.kubernetes.io/memory-pressure"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node.kubernetes.io/pid-pressure"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node.kubernetes.io/network-unavailable"
+      operator: "Exists"
+      effect: "NoSchedule"
+    # Allow eviction during node maintenance
     - operator: "Exists"
       effect: "NoExecute"
   nodeSelector: {}


### PR DESCRIPTION
## Description
Reduces tolerations for the k8s-ksm deployment to improve behavior during node draining & cordoning, preventing the ksm pod from rescheduling onto a cordoned node.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  