### PR TITLE
chore: removing windows 2019 from infra agent build

### DIFF
--- a/.github/workflows/build-win-infra-agent.yml
+++ b/.github/workflows/build-win-infra-agent.yml
@@ -55,8 +55,6 @@ jobs:
       matrix:
         windows:
           - runner: windows-x64-8-core
-            tag: ltsc2019
-          - runner: windows-x64-8-core
             tag: ltsc2022
     runs-on: ${{ matrix.windows.runner }}
     env:


### PR DESCRIPTION
## Description
Windows LTSC 2019 build for the infrastructure agent always fails (integration image builds fine), which cancels the LTSC 2022 build, meaning we have to 1) manually kick-off the cancelled 2022 build & 2) manually build the 2019 image. This at least lets the 2022 image build succeed. We do have a ticket to investigate & fix the failing 2019 build for infra agent.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kubernetes/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  