### PR TITLE
Fix kubelet-daemonset-windows's extraVolumeMounts when provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### bugfix 
 - fixes "bufio.Scanner: token too long" bug by increasing default buffer size @TmNguyen12 [#1407](https://github.com/newrelic/nri-kubernetes/pull/1407)
+- Fix newrelic-infrastructure' kubelet daemonset-windows when `extraVolumeMounts` is provided @zhangyuan [#1380](https://github.com/newrelic/nri-kubernetes/pull/1380)
 
 ### enhancement
 - Add handling for fine-grained kubectl permissions @kondracek-nr [#1389](https://github.com/newrelic/nri-kubernetes/pull/1389)

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
@@ -185,7 +185,7 @@ spec:
             - name: nri-integrations-cfg-volume
               mountPath: "C:\\Program Files\\New Relic\\newrelic-infra\\integrations.d"
             {{- with $.Values.kubelet.extraVolumeMounts }}
-            {{- toYaml $ | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with $.Values.kubelet.resources }}
           resources: {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
## Description

When `extraVolumeMounts` is provided, the current template renders `$` instead of `extraVolumeMounts` (`.`) itself.


## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kubernetes/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  