### PR TITLE
chore: add trivy scans for windows image builds

### DIFF
--- a/.github/workflows/build-win-infra-agent.yml
+++ b/.github/workflows/build-win-infra-agent.yml
@@ -118,3 +118,30 @@ jobs:
           echo "Agent version: $agentVersion"
 
           docker push newrelic/infrastructure-windows:$agentVersion-$matrixTag
+
+  scan:
+    name: Trivy scan for
+    needs: [ check-version-change, build ]
+    strategy:
+      fail-fast: false
+      matrix:
+        windows:
+          - tag: ltsc2022
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: newrelic/infrastructure-windows:${{ needs.check-version-change.outputs.new_agent_version }}-${{ matrix.windows.tag }}
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.K8S_AGENTS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.K8S_AGENTS_DOCKERHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'

--- a/.github/workflows/build-windows-integration-test.yml
+++ b/.github/workflows/build-windows-integration-test.yml
@@ -126,6 +126,15 @@ jobs:
         run: |
           docker push newrelic/nri-kubernetes-internal:$env:DOCKER_TAG
           Write-Output "Pushed newrelic/nri-kubernetes-internal:$env:DOCKER_TAG"
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: newrelic/nri-kubernetes-internal:${{ env.DOCKER_TAG }}
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+
       - name: Output pushed image tag
         shell: powershell
         run: |


### PR DESCRIPTION
## Description
We currently run Trivy scans on our Linux image builds. We should do the same for our Windows builds in order to catch issues.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kubernetes/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  