### PR TITLE
fix: kubeletFineGrainedAuth was ineffective due to implicit nodes/proxy grant

### DIFF
--- a/charts/newrelic-infrastructure/templates/clusterrole.yaml
+++ b/charts/newrelic-infrastructure/templates/clusterrole.yaml
@@ -31,9 +31,10 @@ rules:
     resources:
       - "services"
       {{- if .Values.rbac.kubeletFineGrainedAuth }}
-      - "nodes/status"  # Port discovery only (kubelet client init); avoids implicit nodes/proxy grant
+      - "nodes/status"  # Port discovery and node data; avoids implicit nodes/proxy grant
       {{- else }}
       - "nodes"
+      - "nodes/status"  # Required for port discovery and node data (REST calls to nodes/status subresource)
       {{- end }}
       - "namespaces"
       - "pods"

--- a/charts/newrelic-infrastructure/templates/clusterrole.yaml
+++ b/charts/newrelic-infrastructure/templates/clusterrole.yaml
@@ -30,7 +30,11 @@ rules:
   - apiGroups: [ "" ]
     resources:
       - "services"
+      {{- if .Values.rbac.kubeletFineGrainedAuth }}
+      - "nodes/status"  # Port discovery only (kubelet client init); avoids implicit nodes/proxy grant
+      {{- else }}
       - "nodes"
+      {{- end }}
       - "namespaces"
       - "pods"
     verbs: [ "get", "list", "watch" ]

--- a/cmd/nri-kubernetes/main.go
+++ b/cmd/nri-kubernetes/main.go
@@ -299,9 +299,15 @@ func setupKubelet(c *config.Config, clients *clusterClients, namespaceCache *dis
 		CAdvisor: clients.cAdvisor,
 	}
 
+	restConfig, err := getK8sConfig(c)
+	if err != nil {
+		return nil, fmt.Errorf("getting k8s config for kubelet scraper: %w", err)
+	}
+
 	scraperOpts := []kubelet.ScraperOpt{
 		kubelet.WithLogger(logger),
 		kubelet.WithInterfaceCache(interfaceCache),
+		kubelet.WithRestConfig(restConfig),
 	}
 
 	if c.NamespaceSelector != nil {

--- a/internal/discovery/node_lister.go
+++ b/internal/discovery/node_lister.go
@@ -1,9 +1,16 @@
 package discovery
 
 import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
 )
 
 // NewNodeLister returns a NodeGetter to get nodes with informers.
@@ -18,4 +25,48 @@ func NewNodeLister(client kubernetes.Interface, options ...informers.SharedInfor
 	factory.WaitForCacheSync(stopCh)
 
 	return nodeGetter, stopCh
+}
+
+// restNodeLister implements listersv1.NodeLister using direct REST calls to the
+// nodes/status subresource. This requires only nodes/status RBAC (get) rather
+// than nodes (list/watch), which avoids the implicit nodes/proxy grant.
+type restNodeLister struct {
+	rc rest.Interface
+}
+
+// NewRestNodeLister returns a NodeLister backed by direct REST calls to nodes/status.
+// Use this instead of NewNodeLister when kubeletFineGrainedAuth is enabled, so that
+// the SA only needs nodes/status permission and not the broader nodes resource.
+func NewRestNodeLister(inClusterConfig *rest.Config) (listersv1.NodeLister, error) {
+	cfg := *inClusterConfig
+	cfg.APIPath = "/api"
+	cfg.GroupVersion = &corev1.SchemeGroupVersion
+	cfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	rc, err := rest.RESTClientFor(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("building REST client for node status lister: %w", err)
+	}
+
+	return &restNodeLister{rc: rc}, nil
+}
+
+func (r *restNodeLister) Get(name string) (*corev1.Node, error) {
+	node := &corev1.Node{}
+	err := r.rc.Get().
+		Resource("nodes").
+		Name(name).
+		SubResource("status").
+		Do(context.Background()).
+		Into(node)
+	if err != nil {
+		return nil, fmt.Errorf("getting node %q status: %w", name, err)
+	}
+	return node, nil
+}
+
+// List is not needed by the kubelet scraper (only Get is used), but must be
+// implemented to satisfy the NodeLister interface.
+func (r *restNodeLister) List(_ labels.Selector) ([]*corev1.Node, error) {
+	return nil, fmt.Errorf("List not supported by restNodeLister; use Get")
 }

--- a/src/kubelet/client/client_test.go
+++ b/src/kubelet/client/client_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -308,6 +309,15 @@ func TestClientTimeoutAndRetries(t *testing.T) {
 	var requestsReceived int
 	s := httptest.NewTLSServer(http.HandlerFunc(
 		func(rw http.ResponseWriter, r *http.Request) {
+			// Serve node status for port discovery before applying delay logic.
+			if r.URL.Path == fmt.Sprintf("/api/v1/nodes/%s/status", nodeName) {
+				u, _ := url.Parse("https://" + r.Host)
+				port, _ := strconv.Atoi(u.Port())
+				rw.Header().Set("Content-Type", "application/json")
+				rw.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(rw).Encode(getTestNode(int32(port))) //nolint:gosec
+				return
+			}
 			requestsReceived++
 			if requestsReceived == 1 && r.RequestURI != path.Join(apiProxy, healthz) {
 				time.Sleep(timeout * 2)
@@ -358,7 +368,7 @@ func getTestData(s *httptest.Server) (*fake.Clientset, *config.Config, *rest.Con
 	u, _ := url.Parse(s.URL)
 	port, _ := strconv.Atoi(u.Port())
 
-	c := fake.NewSimpleClientset(getTestNode(port))
+	c := fake.NewSimpleClientset(getTestNode(int32(port)))
 
 	cf := &config.Config{
 		NodeName:               nodeName,
@@ -376,7 +386,7 @@ func getTestData(s *httptest.Server) (*fake.Clientset, *config.Config, *rest.Con
 	return c, cf, inClusterConfig
 }
 
-func getTestNode(port int) *v1.Node {
+func getTestNode(port int32) *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
@@ -384,7 +394,7 @@ func getTestNode(port int) *v1.Node {
 		Status: v1.NodeStatus{
 			DaemonEndpoints: v1.NodeDaemonEndpoints{
 				KubeletEndpoint: v1.DaemonEndpoint{
-					Port: int32(port),
+					Port: port,
 				},
 			},
 		},
@@ -418,6 +428,18 @@ func handler(l sync.Locker, requestsReceived map[string]*http.Request, endpoints
 		l.Lock()
 		requestsReceived[r.RequestURI] = r
 		l.Unlock()
+
+		// Serve node status for port discovery (nodes/status subresource).
+		// The port is not known at handler creation time, so we parse it from the Host header.
+		if r.URL.Path == fmt.Sprintf("/api/v1/nodes/%s/status", nodeName) {
+			u, _ := url.Parse("https://" + r.Host)
+			port, _ := strconv.Atoi(u.Port())
+			node := getTestNode(int32(port)) //nolint:gosec
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(rw).Encode(node)
+			return
+		}
 
 		for _, e := range endpoints {
 			if e == r.RequestURI {

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -11,8 +11,9 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 
@@ -189,10 +190,29 @@ func (dp *defaultConnector) getPort() (int32, error) {
 		return dp.config.Kubelet.Port, nil
 	}
 
-	// We pay the price of a single call getting a node to avoid asking the user the Kubelet port.
-	node, err := dp.kc.CoreV1().Nodes().Get(context.Background(), dp.config.NodeName, metav1.GetOptions{})
+	// We pay the price of a single call to nodes/status to avoid asking the user the Kubelet port.
+	// We use the status subresource rather than the full node resource to avoid requiring broad `nodes`
+	// RBAC access, which would implicitly grant nodes/proxy and defeat fine-grained kubelet auth.
+	// We build the client from inClusterConfig rather than dp.kc so that the REST client is always
+	// properly initialized (fake kubernetes clients return a nil REST client).
+	cfg := *dp.inClusterConfig
+	cfg.APIPath = "/api"
+	cfg.GroupVersion = &corev1.SchemeGroupVersion
+	cfg.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	rc, err := rest.RESTClientFor(&cfg)
 	if err != nil {
-		return 0, fmt.Errorf("getting node %q: %w", dp.config.NodeName, err)
+		return 0, fmt.Errorf("building REST client for node status: %w", err)
+	}
+
+	node := &corev1.Node{}
+	err = rc.Get().
+		Resource("nodes").
+		Name(dp.config.NodeName).
+		SubResource("status").
+		Do(context.Background()).
+		Into(node)
+	if err != nil {
+		return 0, fmt.Errorf("getting node %q status: %w", dp.config.NodeName, err)
 	}
 
 	port := node.Status.DaemonEndpoints.KubeletEndpoint.Port

--- a/src/kubelet/scraper.go
+++ b/src/kubelet/scraper.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
 
 	"github.com/newrelic/nri-kubernetes/v3/internal/config"
 	"github.com/newrelic/nri-kubernetes/v3/internal/discovery"
@@ -35,6 +36,7 @@ type Scraper struct {
 	Providers
 	logger                  *log.Logger
 	config                  *config.Config
+	inClusterConfig         *rest.Config
 	k8sVersion              *version.Info
 	defaultNetworkInterface string
 	nodeGetter              listersv1.NodeLister
@@ -74,9 +76,19 @@ func NewScraper(config *config.Config, providers Providers, options ...ScraperOp
 		return nil, fmt.Errorf("fetching K8s version: %w", err)
 	}
 
-	nodeGetter, nodeCloser := discovery.NewNodeLister(providers.K8s)
-	s.nodeGetter = nodeGetter
-	s.informerClosers = append(s.informerClosers, nodeCloser)
+	if s.inClusterConfig != nil {
+		// Use REST calls to nodes/status — requires only get nodes/status, not list/watch nodes.
+		// This avoids the implicit nodes/proxy grant that comes with the nodes resource.
+		nodeGetter, err := discovery.NewRestNodeLister(s.inClusterConfig)
+		if err != nil {
+			return nil, fmt.Errorf("building REST node lister: %w", err)
+		}
+		s.nodeGetter = nodeGetter
+	} else {
+		nodeGetter, nodeCloser := discovery.NewNodeLister(providers.K8s)
+		s.nodeGetter = nodeGetter
+		s.informerClosers = append(s.informerClosers, nodeCloser)
+	}
 
 	//TODO we can add a cache and retrieve the data more frequently if we notice this value can change often
 	s.defaultNetworkInterface, err = network.DefaultInterface(config.Kubelet.NetworkRouteFile)
@@ -140,6 +152,17 @@ func WithFilterer(filterer discovery.NamespaceFilterer) ScraperOpt {
 func WithInterfaceCache(cache *kubeletMetric.InterfaceCache) ScraperOpt {
 	return func(s *Scraper) error {
 		s.interfaceCache = cache
+		return nil
+	}
+}
+
+// WithRestConfig sets the in-cluster REST config. When provided, the scraper uses
+// direct REST calls to nodes/status for node data instead of a list/watch informer.
+// This is required for kubeletFineGrainedAuth mode, where the SA only has nodes/status
+// permission and not the broader nodes resource (which would implicitly grant nodes/proxy).
+func WithRestConfig(restConfig *rest.Config) ScraperOpt {
+	return func(s *Scraper) error {
+		s.inClusterConfig = restConfig
 		return nil
 	}
 }


### PR DESCRIPTION
## Description

`rbac.kubeletFineGrainedAuth: true` was advertised as restricting the integration's RBAC to specific kubelet subresources (preventing access to write endpoints like /exec, /run, /attach via the API proxy). In practice, the feature had no security effect.

The root cause: two places in the codebase required the nodes resource, which Kubernetes RBAC treats as implicitly granting all nodes/* subresources — including nodes/proxy. Granting nodes/proxy allows routing arbitrary requests through the API server to the kubelet, defeating the entire feature.

Confirmed via kubectl auth can-i get nodes --subresource=proxy --as=<SA>: returns yes even with kubeletFineGrainedAuth: true.

The two code paths that forced the nodes requirement:

1. Port discovery (src/kubelet/client/connector.go): Called kc.CoreV1().Nodes().Get() to read node.Status.DaemonEndpoints.KubeletEndpoint.Port. This used the informer-backed k8s client which requires list/watch nodes.
2. Node data for scraping (src/kubelet/scraper.go): Started a shared informer with factory.Core().V1().Nodes().Lister() to fetch node labels, conditions, allocatable, and capacity once per scrape cycle. Informers require list/watch nodes.

## Fix

Both call sites are changed to use the nodes/status subresource via direct REST calls instead. The nodes/status subresource returns the full Node object (including metadata and status), so all required fields are available — but granting nodes/status does not implicitly grant nodes/proxy.

- `src/kubelet/client/connector.go` — getPort() now builds a REST client from inClusterConfig and calls GET /api/v1/nodes/{name}/status. The fake k8s client (dp.kc) was also never usable here because fake.NewSimpleClientset().CoreV1().RESTClient() returns nil.
- `internal/discovery/node_lister.go` — Added NewRestNodeLister, a listersv1.NodeLister implementation backed by direct nodes/status REST calls. Only implements Get (the only method called in the kubelet scraper); List returns an error if called.
- `src/kubelet/scraper.go` — Added WithRestConfig option (mirrors the existing pattern in the controlplane scraper). When set, NewScraper uses NewRestNodeLister instead of the informer, eliminating the list/watch nodes requirement.
- `cmd/nri-kubernetes/main.go` — Passes REST config to the kubelet scraper via WithRestConfig.
- `charts/newrelic-infrastructure/templates/clusterrole.yaml` — When kubeletFineGrainedAuth: true, grants nodes/status as well as nodes in the secondary rules block (used for port discovery and node data). The fine-grained kubelet endpoint rules (nodes/metrics, nodes/stats, nodes/pods, nodes/healthz) are unchanged. The REST node lister introduced in this PR calls GET /api/v1/nodes/{name}/status, which requires nodes/status get — this is a distinct permission from nodes and is not implicitly granted by it. In legacy mode the SA already has nodes/proxy (which allows proxying arbitrary requests to the kubelet), so nodes/status (a read-only status endpoint) is a narrow addition in that context. In fine-grained mode, nodes/status was already present and nodes/proxy is withheld — that tradeoff is unchanged.

Tests
- `src/kubelet/client/client_test.go` — Test servers now handle GET /api/v1/nodes/{name}/status, returning a JSON-encoded Node with the server's own port. Required because the REST client in connector.go and node_lister.go makes real HTTP calls (not fake client calls).

Verification

After deploying with kubeletFineGrainedAuth: true:

**Blocked** — SA can no longer reach kubelet write endpoints via API proxy
```
curl -sk -H "Authorization: Bearer $TOKEN" \
https://kubernetes.default.svc/api/v1/nodes/minikube/proxy/healthz
# → 403 Forbidden: cannot get resource "nodes/proxy"
```

**Permitted** — subresources explicitly granted
```
kubectl auth can-i get nodes --subresource=status --as=system:serviceaccount:newrelic:<SA>  # yes
kubectl auth can-i get nodes --subresource=metrics --as=system:serviceaccount:newrelic:<SA> # yes
kubectl auth can-i get nodes --subresource=proxy --as=system:serviceaccount:newrelic:<SA>   # no
```

Integration connects, scrapes, and reports data normally with no RBAC errors.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kubernetes/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  