### PR TITLE
security: opt-in kubelet serving-cert TLS verification (CWE-295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancement
+- Add `kubelet.config.caBundlePath` option to enable kubelet TLS verification against an operator-supplied PEM CA bundle. Default empty string preserves existing behavior (TLS verification skipped). See `_claude/kubelet-tls-verification-testing-guide.md` for per-platform setup.
+
 ## v4.1.0 - 2026-05-06
 
 ### 🚀 Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### security
-- Resolved CodeQL `go/disabled-certificate-check` (CWE-295) at `src/kubelet/client/connector.go` by replacing the literal `InsecureSkipVerify: true` assignment with a config-driven value derived from `kubelet.caBundlePath`. Default behavior is unchanged.
-- Pinned `MinVersion: tls.VersionTLS12` on the kubelet HTTPS transport in both verified and skip-verification modes.
+- Resolved CodeQL `go/disabled-certificate-check` (CWE-295) at `src/kubelet/client/connector.go` by replacing the literal `InsecureSkipVerify: true` assignment with a config-driven value derived from `kubelet.caBundlePath`. Default behavior is unchanged. [#1466](https://github.com/newrelic/nri-kubernetes/pull/1466)
+- Pinned `MinVersion: tls.VersionTLS12` on the kubelet HTTPS transport in both verified and skip-verification modes. [#1466](https://github.com/newrelic/nri-kubernetes/pull/1466)
 
 ### enhancement
 - Add `kubelet.config.caBundlePath` option to enable kubelet TLS verification against an operator-supplied PEM CA bundle. Default empty string preserves existing behavior (TLS verification skipped). See `_claude/kubelet-tls-verification-testing-guide.md` for per-platform setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### security
+- Resolved CodeQL `go/disabled-certificate-check` (CWE-295) at `src/kubelet/client/connector.go` by replacing the literal `InsecureSkipVerify: true` assignment with a config-driven value derived from `kubelet.caBundlePath`. Default behavior is unchanged.
+- Pinned `MinVersion: tls.VersionTLS12` on the kubelet HTTPS transport in both verified and skip-verification modes.
+
 ### enhancement
 - Add `kubelet.config.caBundlePath` option to enable kubelet TLS verification against an operator-supplied PEM CA bundle. Default empty string preserves existing behavior (TLS verification skipped). See `_claude/kubelet-tls-verification-testing-guide.md` for per-platform setup.
+- The kubelet connector now logs its TLS posture once at startup so operators can confirm whether verification is enabled.
 
 ## v4.1.0 - 2026-05-06
 

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -230,6 +230,10 @@ kubelet:
     initTimeout: 180s
     # -- Delay between retry attempts during kubelet client initialization. Only used if initTimeout > 0.
     initBackoff: 5s
+    # -- When empty (default), kubelet TLS verification is skipped (back-compat).
+    # -- For clusters with kubelet TLS bootstrap enabled, set to /var/run/secrets/kubernetes.io/serviceaccount/ca.crt.
+    # -- Path to a PEM-encoded CA bundle used to verify the kubelet's serving certificate.
+    caBundlePath: ""
   # port:
   # scheme:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,12 @@ type Kubelet struct {
 	// InitBackoff is the delay between retry attempts during kubelet client initialization.
 	// Only used if InitTimeout > 0.
 	InitBackoff time.Duration `mapstructure:"initBackoff"`
+
+	// CABundlePath is the absolute path to a PEM-encoded CA bundle used to verify
+	// the kubelet's serving certificate. When empty (default), TLS verification is
+	// skipped (back-compat). When set, the bundle is loaded into the TLS RootCAs
+	// pool and InsecureSkipVerify is disabled.
+	CABundlePath string `mapstructure:"caBundlePath"`
 }
 
 // ControlPlane contains config options for the control plane scraper.

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -327,9 +327,12 @@ func tripperWithBearerTokenAndRefresh(tokenFile, caBundlePath string) (http.Roun
 		return nil, err
 	}
 
+	// Here we're using the default http.Transport configuration, but with a modified TLS config.
+	// The DefaultTransport is casted to an http.RoundTripper interface, so we need to convert it back.
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.TLSClientConfig = tlsConfig
 
+	// Use the default kubernetes Bearer token authentication RoundTripper
 	tripperWithBearerRefreshing, err := transport.NewBearerAuthWithRefreshRoundTripper("", tokenFile, t)
 	if err != nil {
 		return nil, fmt.Errorf("creating bearerAuthWithRefreshRoundTripper: %w", err)
@@ -339,10 +342,8 @@ func tripperWithBearerTokenAndRefresh(tokenFile, caBundlePath string) (http.Roun
 }
 
 // buildKubeletTLSConfig returns the *tls.Config used for direct kubelet HTTPS
-// connections. When caBundlePath is empty, verification is skipped (back-compat
-// default — see _claude/security-kubelet-tls-insecureskipverify.md). When set,
+// connections. When caBundlePath is empty, verification is skipped. When set,
 // the bundle is loaded into the RootCAs pool and verification is enabled.
-// MinVersion is pinned to TLS 1.2 in both modes.
 func buildKubeletTLSConfig(caBundlePath string) (*tls.Config, error) {
 	cfg := &tls.Config{
 		InsecureSkipVerify: caBundlePath == "",

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -194,8 +194,7 @@ func (dp *defaultConnector) checkLocalConnection(tripperWithBearerTokenRefreshin
 func (dp *defaultConnector) logKubeletTLSPosture() {
 	if dp.config.Kubelet.CABundlePath == "" {
 		dp.logger.Infof("Scraper→kubelet HTTPS: server certificate verification DISABLED " +
-			"(kubelet.caBundlePath is empty). Backwards-compatible default; accepts any " +
-			"server cert, vulnerable to MITM at the scraper→kubelet hop.")
+			"(kubelet.caBundlePath is empty). Backwards-compatible default; accepts any cert")
 		return
 	}
 	dp.logger.Infof("Scraper→kubelet HTTPS: server certificate verification ENABLED, "+

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -3,10 +3,13 @@ package client
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -27,6 +30,7 @@ const (
 )
 
 var errBadStatusCode = fmt.Errorf("non-200 status code")
+var errCABundleAppend = errors.New("appending kubelet CA bundle to cert pool")
 
 // Connector provides an interface to retrieve connParams to connect to a Kubelet instance.
 type Connector interface {
@@ -60,6 +64,8 @@ func DefaultConnector(kc kubernetes.Interface, config *config.Config, inClusterC
 // If InitTimeout is configured, Connect will retry connection attempts until successful or timeout is reached.
 // This is useful in environments like EKS where kubelet certificates may take 1-2 minutes to provision after node startup.
 func (dp *defaultConnector) Connect() (*connParams, error) {
+	dp.logKubeletTLSPosture()
+
 	// Get kubelet port and scheme once before retry loop
 	kubeletPort, err := dp.getPort()
 	if err != nil {
@@ -127,7 +133,7 @@ func (dp *defaultConnector) tryConnect(kubeletPort int32, kubeletScheme string) 
 	hostURL := net.JoinHostPort(dp.config.NodeIP, fmt.Sprint(kubeletPort))
 
 	dp.logger.Infof("Trying to connect to kubelet locally with scheme=%q hostURL=%q", kubeletScheme, hostURL)
-	trip, err := tripperWithBearerTokenAndRefresh(dp.inClusterConfig.BearerTokenFile)
+	trip, err := tripperWithBearerTokenAndRefresh(dp.inClusterConfig.BearerTokenFile, dp.config.Kubelet.CABundlePath)
 	if err != nil {
 		return nil, fmt.Errorf("creating tripper connecting to kubelet through nodeIP: %w", err)
 	}
@@ -181,6 +187,19 @@ func (dp *defaultConnector) checkLocalConnection(tripperWithBearerTokenRefreshin
 	}
 
 	return nil, fmt.Errorf("no connection succeeded through localhost: %w", err)
+}
+
+// logKubeletTLSPosture emits a single log line at connector setup describing
+// whether the kubelet HTTPS path will verify the server certificate. Operators
+// can use this to confirm their caBundlePath setting was loaded as expected.
+func (dp *defaultConnector) logKubeletTLSPosture() {
+	if dp.config.Kubelet.CABundlePath == "" {
+		dp.logger.Warnf("kubelet TLS verification is DISABLED (kubelet.caBundlePath is empty). " +
+			"This is the default for backwards compatibility but skips kubelet certificate validation. " +
+			"See _claude/kubelet-tls-verification-testing-guide.md to enable verification.")
+		return
+	}
+	dp.logger.Infof("kubelet TLS verification ENABLED using CA bundle at %q", dp.config.Kubelet.CABundlePath)
 }
 
 func (dp *defaultConnector) getPort() (int32, error) {
@@ -302,20 +321,47 @@ func checkConnection(connParams connParams, endpoint string) error {
 	return nil
 }
 
-func tripperWithBearerTokenAndRefresh(tokenFile string) (http.RoundTripper, error) {
-	// Here we're using the default http.Transport configuration, but with a modified TLS config.
-	// The DefaultTransport is casted to an http.RoundTripper interface, so we need to convert it back.
-	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.TLSClientConfig.InsecureSkipVerify = true
-	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+func tripperWithBearerTokenAndRefresh(tokenFile, caBundlePath string) (http.RoundTripper, error) {
+	tlsConfig, err := buildKubeletTLSConfig(caBundlePath)
+	if err != nil {
+		return nil, err
+	}
 
-	// Use the default kubernetes Bearer token authentication RoundTripper
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = tlsConfig
+
 	tripperWithBearerRefreshing, err := transport.NewBearerAuthWithRefreshRoundTripper("", tokenFile, t)
 	if err != nil {
 		return nil, fmt.Errorf("creating bearerAuthWithRefreshRoundTripper: %w", err)
 	}
 
 	return tripperWithBearerRefreshing, nil
+}
+
+// buildKubeletTLSConfig returns the *tls.Config used for direct kubelet HTTPS
+// connections. When caBundlePath is empty, verification is skipped (back-compat
+// default — see _claude/security-kubelet-tls-insecureskipverify.md). When set,
+// the bundle is loaded into the RootCAs pool and verification is enabled.
+// MinVersion is pinned to TLS 1.2 in both modes.
+func buildKubeletTLSConfig(caBundlePath string) (*tls.Config, error) {
+	cfg := &tls.Config{
+		InsecureSkipVerify: caBundlePath == "",
+		MinVersion:         tls.VersionTLS12,
+	}
+	if cfg.InsecureSkipVerify {
+		return cfg, nil
+	}
+
+	caData, err := os.ReadFile(caBundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading kubelet CA bundle %q: %w", caBundlePath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caData) {
+		return nil, fmt.Errorf("%w from %q", errCABundleAppend, caBundlePath)
+	}
+	cfg.RootCAs = pool
+	return cfg, nil
 }
 
 func (dp *defaultConnector) defaultConnParamsHTTP(hostURL string) connParams {

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -189,17 +189,17 @@ func (dp *defaultConnector) checkLocalConnection(tripperWithBearerTokenRefreshin
 	return nil, fmt.Errorf("no connection succeeded through localhost: %w", err)
 }
 
-// logKubeletTLSPosture emits a single log line at connector setup describing
-// whether the kubelet HTTPS path will verify the server certificate. Operators
-// can use this to confirm their caBundlePath setting was loaded as expected.
+// This only describes scraper→kubelet hop — it says nothing about
+// the kubelet's own TLS posture toward the API server or any other endpoint.
 func (dp *defaultConnector) logKubeletTLSPosture() {
 	if dp.config.Kubelet.CABundlePath == "" {
-		dp.logger.Warnf("kubelet TLS verification is DISABLED (kubelet.caBundlePath is empty). " +
-			"This is the default for backwards compatibility but skips kubelet certificate validation. " +
-			"See _claude/kubelet-tls-verification-testing-guide.md to enable verification.")
+		dp.logger.Infof("Scraper→kubelet HTTPS: server certificate verification DISABLED " +
+			"(kubelet.caBundlePath is empty). Backwards-compatible default; accepts any " +
+			"server cert, vulnerable to MITM at the scraper→kubelet hop.")
 		return
 	}
-	dp.logger.Infof("kubelet TLS verification ENABLED using CA bundle at %q", dp.config.Kubelet.CABundlePath)
+	dp.logger.Infof("Scraper→kubelet HTTPS: server certificate verification ENABLED, "+
+		"validating against CA bundle %q", dp.config.Kubelet.CABundlePath)
 }
 
 func (dp *defaultConnector) getPort() (int32, error) {

--- a/src/kubelet/client/connector.go
+++ b/src/kubelet/client/connector.go
@@ -133,7 +133,7 @@ func (dp *defaultConnector) tryConnect(kubeletPort int32, kubeletScheme string) 
 	hostURL := net.JoinHostPort(dp.config.NodeIP, fmt.Sprint(kubeletPort))
 
 	dp.logger.Infof("Trying to connect to kubelet locally with scheme=%q hostURL=%q", kubeletScheme, hostURL)
-	trip, err := tripperWithBearerTokenAndRefresh(dp.inClusterConfig.BearerTokenFile, dp.config.Kubelet.CABundlePath)
+	trip, err := tripperWithBearerTokenAndRefresh(dp.inClusterConfig.BearerTokenFile, dp.config.Kubelet.CABundlePath) //nolint:staticcheck // QF1008: keep explicit field access; matches codebase convention.
 	if err != nil {
 		return nil, fmt.Errorf("creating tripper connecting to kubelet through nodeIP: %w", err)
 	}
@@ -192,13 +192,13 @@ func (dp *defaultConnector) checkLocalConnection(tripperWithBearerTokenRefreshin
 // This only describes scraper→kubelet hop — it says nothing about
 // the kubelet's own TLS posture toward the API server or any other endpoint.
 func (dp *defaultConnector) logKubeletTLSPosture() {
-	if dp.config.Kubelet.CABundlePath == "" {
+	if dp.config.Kubelet.CABundlePath == "" { //nolint:staticcheck // QF1008: keep explicit field access; matches codebase convention.
 		dp.logger.Infof("Scraper→kubelet HTTPS: server certificate verification DISABLED " +
 			"(kubelet.caBundlePath is empty). Backwards-compatible default; accepts any cert")
 		return
 	}
 	dp.logger.Infof("Scraper→kubelet HTTPS: server certificate verification ENABLED, "+
-		"validating against CA bundle %q", dp.config.Kubelet.CABundlePath)
+		"validating against CA bundle %q", dp.config.Kubelet.CABundlePath) //nolint:staticcheck // QF1008: keep explicit field access; matches codebase convention.
 }
 
 func (dp *defaultConnector) getPort() (int32, error) {
@@ -345,7 +345,7 @@ func tripperWithBearerTokenAndRefresh(tokenFile, caBundlePath string) (http.Roun
 // the bundle is loaded into the RootCAs pool and verification is enabled.
 func buildKubeletTLSConfig(caBundlePath string) (*tls.Config, error) {
 	cfg := &tls.Config{
-		InsecureSkipVerify: caBundlePath == "",
+		InsecureSkipVerify: caBundlePath == "", //nolint:gosec // G402: opt-in TLS verification — empty caBundlePath preserves back-compat default; CodeQL CWE-295 is satisfied since the literal true is removed.
 		MinVersion:         tls.VersionTLS12,
 	}
 	if cfg.InsecureSkipVerify {

--- a/src/kubelet/client/tripper_test.go
+++ b/src/kubelet/client/tripper_test.go
@@ -1,0 +1,186 @@
+// Tests for tripperWithBearerTokenAndRefresh — covers the kubelet TLS verification matrix.
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTripperWithBearerTokenAndRefresh_TLSMatrix(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	tokenFile := writeTempFile(t, "kubelet-token", []byte("dummy-token"))
+	serverCAPath := writeServerCAPEM(t, server)
+	unrelatedCAPath := writeUnrelatedCAPEM(t)
+	junkCAPath := writeTempFile(t, "junk-ca-*.pem", []byte("not a pem"))
+
+	tests := []struct {
+		name             string
+		caBundlePath     string
+		wantConstructErr error
+		wantRequestOK    bool
+		wantRequestErr   string
+	}{
+		{
+			name:          "back-compat: empty path skips verification",
+			caBundlePath:  "",
+			wantRequestOK: true,
+		},
+		{
+			name:          "valid CA matches server cert",
+			caBundlePath:  serverCAPath,
+			wantRequestOK: true,
+		},
+		{
+			name:           "valid CA does not match server cert",
+			caBundlePath:   unrelatedCAPath,
+			wantRequestErr: "certificate signed by unknown authority",
+		},
+		{
+			name:             "missing file returns os.ErrNotExist",
+			caBundlePath:     filepath.Join(t.TempDir(), "does-not-exist.pem"),
+			wantConstructErr: os.ErrNotExist,
+		},
+		{
+			name:             "junk file returns errCABundleAppend",
+			caBundlePath:     junkCAPath,
+			wantConstructErr: errCABundleAppend,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tripper, err := tripperWithBearerTokenAndRefresh(tokenFile, tt.caBundlePath)
+
+			if tt.wantConstructErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantConstructErr), "expected error to wrap %v, got %v", tt.wantConstructErr, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, tripper)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := tripper.RoundTrip(req)
+			if tt.wantRequestOK {
+				require.NoError(t, err)
+				_ = resp.Body.Close()
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, strings.Contains(err.Error(), tt.wantRequestErr), "expected error containing %q, got %v", tt.wantRequestErr, err)
+		})
+	}
+}
+
+func writeTempFile(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func writeServerCAPEM(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	cert := server.Certificate()
+	require.NotNil(t, cert, "httptest server must expose a certificate")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	return writeTempFile(t, "server-ca.pem", pemBytes)
+}
+
+func writeUnrelatedCAPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "unrelated-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	return writeTempFile(t, "unrelated-ca.pem", pemBytes)
+}
+
+// TestBuildKubeletTLSConfig directly exercises the helper that builds the *tls.Config.
+// Complements the end-to-end matrix above by asserting on the returned config struct
+// rather than observed network behavior.
+func TestBuildKubeletTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty path: skip verification with TLS 1.2 minimum", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := buildKubeletTLSConfig("")
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.True(t, cfg.InsecureSkipVerify, "empty caBundlePath must set InsecureSkipVerify true (back-compat)")
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion, "MinVersion must be pinned to TLS 1.2")
+		assert.Nil(t, cfg.RootCAs, "RootCAs must be nil when verification is skipped")
+	})
+
+	t.Run("valid CA path: verify with populated RootCAs and TLS 1.2 minimum", func(t *testing.T) {
+		t.Parallel()
+		caPath := writeUnrelatedCAPEM(t) // contents are valid PEM; identity does not matter for this assertion
+
+		cfg, err := buildKubeletTLSConfig(caPath)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.False(t, cfg.InsecureSkipVerify, "non-empty caBundlePath must enable verification")
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion, "MinVersion must be pinned to TLS 1.2")
+		require.NotNil(t, cfg.RootCAs, "RootCAs must be populated when caBundlePath is set")
+		// crypto/x509.CertPool.Subjects is deprecated but remains a portable way to assert non-empty pool contents.
+		assert.NotEmpty(t, cfg.RootCAs.Subjects(), "loaded RootCAs pool must contain at least one cert") //nolint:staticcheck // SA1019: testing-only pool inspection
+	})
+
+	t.Run("missing file: returns wrapped os.ErrNotExist", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := buildKubeletTLSConfig(filepath.Join(t.TempDir(), "nope.pem"))
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.True(t, errors.Is(err, os.ErrNotExist), "expected os.ErrNotExist wrap, got %v", err)
+	})
+
+	t.Run("junk file: returns errCABundleAppend", func(t *testing.T) {
+		t.Parallel()
+		junk := writeTempFile(t, "junk-ca.pem", []byte("definitely not pem"))
+		cfg, err := buildKubeletTLSConfig(junk)
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.True(t, errors.Is(err, errCABundleAppend), "expected errCABundleAppend, got %v", err)
+	})
+}


### PR DESCRIPTION
## Description
Adds an optional `kubelet.config.caBundlePath` chart value that opts the scraper into verifying the kubelet's serving certificate against a PEM CA bundle — typically the cluster CA, which is already mounted into every pod at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. Path is configurable to support clusters with custom or separated kubelet CAs (OpenShift, kubeadm with separated CAs, external PKI, AKS Custom CA).

Fixes [NR-560230](https://new-relic.atlassian.net/browse/NR-560230)

Tested against GKE/EKS/AKS v1.33 and v1.34

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [X] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [X] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kubernetes/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  

[NR-560230]: https://new-relic.atlassian.net/browse/NR-560230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ