### PR TITLE
feat: Enable configuration of passthrough environment variables for On-host integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### enhancement
+- Allow configuring passthrough environment variables for On-host integrations via `kubelet.extraPassthroughEnv`. Resolves #1491. @dbudziwojski [#1513](https://github.com/newrelic/nri-kubernetes/pull/1513)
+
 ## v4.4.1 - 2026-07-20
 
 ### ⛓️ Dependencies

--- a/charts/newrelic-infrastructure/templates/kubelet/_agent-config_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_agent-config_helper.tpl
@@ -29,3 +29,14 @@ enable_process_metrics: {{ .Values.enableProcessMetrics }}
 
 {{- mustMergeOverwrite $agentDefaults $kubelet $agentConfig $kubeletAgentConfig $customAttributes | toYaml -}}
 {{- end -}}
+
+{{- /*
+Builds the comma-separated list of environment variable names or regexes to be passed into
+NRIA_PASSTHROUGH_ENVIRONMENT, always including `CLUSTER_NAME` plus any user-defined
+`kubelet.extraPassthroughEnv`.
+*/ -}}
+{{- define "nriKubernetes.kubelet.passthroughEnv" -}}
+{{- $passthroughEnv := concat (list "CLUSTER_NAME") .Values.kubelet.extraPassthroughEnv -}}
+{{- join "," $passthroughEnv -}}
+{{- end -}}
+

--- a/charts/newrelic-infrastructure/templates/kubelet/_agent-config_helper.tpl
+++ b/charts/newrelic-infrastructure/templates/kubelet/_agent-config_helper.tpl
@@ -36,7 +36,8 @@ NRIA_PASSTHROUGH_ENVIRONMENT, always including `CLUSTER_NAME` plus any user-defi
 `kubelet.extraPassthroughEnv`.
 */ -}}
 {{- define "nriKubernetes.kubelet.passthroughEnv" -}}
-{{- $passthroughEnv := concat (list "CLUSTER_NAME") .Values.kubelet.extraPassthroughEnv -}}
+{{- $extraPassthroughEnv := .Values.kubelet.extraPassthroughEnv | default list -}}
+{{- $passthroughEnv := concat (list "CLUSTER_NAME") $extraPassthroughEnv -}}
 {{- join "," $passthroughEnv -}}
 {{- end -}}
 

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset-windows.yaml
@@ -205,7 +205,7 @@ spec:
             - name: "CLUSTER_NAME"
               value: {{ include "newrelic.common.cluster" $ }}
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "CLUSTER_NAME"
+              value: {{ include "nriKubernetes.kubelet.passthroughEnv" $ | quote }}
 
             {{- /* Needed for autodiscovery when hostNetwork=false (unprivileged mode) */}}
             {{- if not (include "nriKubernetes.windows.privileged" $) }}

--- a/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
+++ b/charts/newrelic-infrastructure/templates/kubelet/daemonset.yaml
@@ -177,7 +177,7 @@ spec:
             - name: "CLUSTER_NAME"
               value: {{ include "newrelic.common.cluster" . }}
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "CLUSTER_NAME"
+              value: {{ include "nriKubernetes.kubelet.passthroughEnv" . | quote }}
 
             {{- /* Needed for autodiscovery since hostNetwork=false */}}
             - name: "NRIA_HOST"

--- a/charts/newrelic-infrastructure/tests/passthrough_env_test.yaml
+++ b/charts/newrelic-infrastructure/tests/passthrough_env_test.yaml
@@ -1,0 +1,71 @@
+suite: test NRIA_PASSTHROUGH_ENVIRONMENT
+templates:
+  - templates/kubelet/daemonset.yaml
+  - templates/kubelet/daemonset-windows.yaml
+  - templates/kubelet/scraper-configmap.yaml
+  - templates/kubelet/agent-configmap.yaml
+  - templates/kubelet/integrations-configmap.yaml
+  - templates/agent-configmap.yaml
+  - templates/secret.yaml
+tests:
+  - it: only contains CLUSTER_NAME by default
+    set:
+      enableWindows: true
+      licenseKey: test
+      cluster: test
+    asserts:
+      - template: templates/kubelet/daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+            value: "CLUSTER_NAME"
+      - template: templates/kubelet/daemonset-windows.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+            value: "CLUSTER_NAME"
+
+  - it: appends a single extraPassthroughEnv entry after CLUSTER_NAME
+    set:
+      enableWindows: true
+      licenseKey: test
+      cluster: test
+      kubelet.extraPassthroughEnv:
+        - MY_ENV_VAR
+    asserts:
+      - template: templates/kubelet/daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+            value: "CLUSTER_NAME,MY_ENV_VAR"
+      - template: templates/kubelet/daemonset-windows.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+            value: "CLUSTER_NAME,MY_ENV_VAR"
+
+  - it: joins multiple extraPassthroughEnv entries into a csv after CLUSTER_NAME
+    set:
+      enableWindows: true
+      licenseKey: test
+      cluster: test
+      kubelet.extraPassthroughEnv:
+        - FOO
+        - BAR
+    asserts:
+      - template: templates/kubelet/daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+            value: "CLUSTER_NAME,FOO,BAR"
+      - template: templates/kubelet/daemonset-windows.yaml
+        contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: "NRIA_PASSTHROUGH_ENVIRONMENT"
+            value: "CLUSTER_NAME,FOO,BAR"

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -180,7 +180,7 @@ kubelet:
   extraEnv: []
   # -- Add user environment from configMaps or secrets as variables to the agent
   extraEnvFrom: []
-  # -- List of additional environment variable names or regexes to passthrough to Infrastructure agent integrations. These environment variables must already be passed in with `extraEnv` or `extraEnvFrom` above
+  # -- List of additional environment variable names or regexes to passthrough to Infrastructure agent On-host integrations. These environment variables must already be passed in with `extraEnv` or `extraEnvFrom` above
   extraPassthroughEnv: []
   # -- Volumes to mount in the containers
   extraVolumes: []

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -172,17 +172,16 @@ kubelet:
   # -- Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster.
   # It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in
   # [New Relic docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/)
-  # e.g. you can set `passthrough_environment` int the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file)
-  # so the agent let use that environment variables to the integrations.
+  # e.g. you can set `event_queue_depth` in the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file)
   agentConfig: {}
-  # passthrough_environment:
-  #   - A_ENVIRONMENT_VARIABLE_SET_IN_extraEnv
-  #   - A_ENVIRONMENT_VARIABLE_SET_IN_A_CONFIG_MAP_SET_IN_entraEnvForm
+  # event_queue_depth: 2000
 
   # -- Add user environment variables to the agent
   extraEnv: []
   # -- Add user environment from configMaps or secrets as variables to the agent
   extraEnvFrom: []
+  # -- List of additional environment variable names or regexes to passthrough to Infrastructure agent integrations. These environment variables must already be passed in with `extraEnv` or `extraEnvFrom` above
+  extraPassthroughEnv: []
   # -- Volumes to mount in the containers
   extraVolumes: []
   # -- Defines where to mount volumes specified with `extraVolumes`

--- a/charts/newrelic-infrastructure/values.yaml
+++ b/charts/newrelic-infrastructure/values.yaml
@@ -172,7 +172,7 @@ kubelet:
   # -- Config for the Infrastructure agent that will forward the metrics to the backend and will run the integrations in this cluster.
   # It will be merged with the configuration in `.common.agentConfig`. You can see all the agent configurations in
   # [New Relic docs](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/)
-  # e.g. you can set `event_queue_depth` in the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file)
+  # e.g. you can change the `event_queue_depth` in the [config file](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#config-file)
   agentConfig: {}
   # event_queue_depth: 2000
 


### PR DESCRIPTION
## Description
Allow configuring passthrough environment variables for On-host integrations via `kubelet.extraPassthroughEnv`. Resolves #1491.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kubernetes/blob/main/CONTRIBUTING.md#pull-requests)
- [X] Documentation has been updated
- [ ] This change requires changes in testing:
  - [X] unit tests
  - [ ] E2E tests
  